### PR TITLE
feat: add property tests for ID generation #44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -173,6 +179,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -279,7 +306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -525,7 +552,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -550,7 +577,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -561,6 +588,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -575,12 +612,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -600,6 +643,7 @@ checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 name = "fluxapay"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -608,6 +652,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -634,13 +684,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -657,6 +732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -718,6 +802,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -801,6 +891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +907,12 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
@@ -958,6 +1060,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,14 +1094,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -984,7 +1133,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -993,7 +1152,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1017,6 +1194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,10 +1219,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1204,7 +1412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1241,7 +1449,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1269,7 +1477,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1277,8 +1485,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1287,7 +1495,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1331,7 +1539,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1372,7 +1580,7 @@ dependencies = [
  "base64",
  "stellar-xdr",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1490,6 +1698,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,10 +1768,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -1570,10 +1803,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1621,6 +1881,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1926,18 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
 ]
@@ -1714,6 +2008,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/fluxapay/Cargo.toml
+++ b/fluxapay/Cargo.toml
@@ -13,3 +13,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = "1.4.0"

--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -25,7 +25,7 @@ fn test_create_dispute() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (_admin, payment_client, refund_client) = setup_contracts(&env);
+    let (admin, payment_client, refund_client) = setup_contracts(&env);
     let merchant = Address::generate(&env);
     let customer = Address::generate(&env);
 
@@ -48,7 +48,7 @@ fn test_create_dispute() {
     // Verify payment
     let transaction_hash = BytesN::<32>::random(&env);
     let oracle = Address::generate(&env);
-    payment_client.grant_role(&_admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
     payment_client.verify_payment(&oracle, &payment_id, &transaction_hash, &customer, &amount);
 
     // Create dispute
@@ -98,7 +98,7 @@ fn test_review_dispute() {
 
     let transaction_hash = BytesN::<32>::random(&env);
     let oracle = Address::generate(&env);
-    payment_client.grant_role(&_admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
     payment_client.verify_payment(&oracle, &payment_id, &transaction_hash, &customer, &amount);
 
     // Create dispute
@@ -148,7 +148,7 @@ fn test_resolve_dispute_with_refund() {
 
     let transaction_hash = BytesN::<32>::random(&env);
     let oracle = Address::generate(&env);
-    payment_client.grant_role(&_admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
     payment_client.verify_payment(&oracle, &payment_id, &transaction_hash, &customer, &amount);
 
     // Create dispute
@@ -208,7 +208,7 @@ fn test_reject_dispute() {
 
     let transaction_hash = BytesN::<32>::random(&env);
     let oracle = Address::generate(&env);
-    payment_client.grant_role(&_admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
     payment_client.verify_payment(&oracle, &payment_id, &transaction_hash, &customer, &amount);
 
     // Create dispute
@@ -234,7 +234,7 @@ fn test_get_payment_disputes() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (_, payment_client, refund_client) = setup_contracts(&env);
+    let (admin, payment_client, refund_client) = setup_contracts(&env);
     let merchant = Address::generate(&env);
     let customer = Address::generate(&env);
 
@@ -256,7 +256,7 @@ fn test_get_payment_disputes() {
 
     let transaction_hash = BytesN::<32>::random(&env);
     let oracle = Address::generate(&env);
-    payment_client.grant_role(&_admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
     payment_client.verify_payment(&oracle, &payment_id, &transaction_hash, &customer, &amount);
 
     // Create multiple disputes

--- a/fluxapay/src/integration_test.rs
+++ b/fluxapay/src/integration_test.rs
@@ -50,8 +50,9 @@ fn test_happy_path_flow() {
     payment_client.create_payment(&payment_id, &merchant, &amount, &Symbol::new(&env, "USDC"), &Address::generate(&env), &expires_at);
     
     let tx_hash = BytesN::<32>::random(&env);
-    // Note: using original verify_payment signature for this branch
-    payment_client.verify_payment(&payment_id, &tx_hash, &customer, &amount);
+    let oracle = Address::generate(&env);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.verify_payment(&oracle, &payment_id, &tx_hash, &customer, &amount);
     
     let payment_info = payment_client.get_payment(&payment_id);
     assert_eq!(payment_info.status, PaymentStatus::Confirmed);
@@ -89,7 +90,9 @@ fn test_settlement_path() {
     let amount = 2000i128;
     payment_client.create_payment(&payment_id, &merchant, &amount, &Symbol::new(&env, "USDC"), &Address::generate(&env), &(env.ledger().timestamp() + 3600));
     
-    payment_client.verify_payment(&payment_id, &BytesN::<32>::random(&env), &customer, &amount);
+    let oracle = Address::generate(&env);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.verify_payment(&oracle, &payment_id, &BytesN::<32>::random(&env), &customer, &amount);
     
     // Settle payment (Sweep to treasury)
     payment_client.settle_payment(&operator, &payment_id, &treasury);

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -177,58 +177,7 @@ impl RefundManager {
         // Build refund ID: "refund_" + counter
         // For simplicity and to avoid complex string manipulation in no_std,
         // we use a match statement for common cases
-        let refund_id = match counter {
-            1 => String::from_str(&env, "refund_1"),
-            2 => String::from_str(&env, "refund_2"),
-            3 => String::from_str(&env, "refund_3"),
-            4 => String::from_str(&env, "refund_4"),
-            5 => String::from_str(&env, "refund_5"),
-            6 => String::from_str(&env, "refund_6"),
-            7 => String::from_str(&env, "refund_7"),
-            8 => String::from_str(&env, "refund_8"),
-            9 => String::from_str(&env, "refund_9"),
-            10 => String::from_str(&env, "refund_10"),
-            11 => String::from_str(&env, "refund_11"),
-            12 => String::from_str(&env, "refund_12"),
-            13 => String::from_str(&env, "refund_13"),
-            14 => String::from_str(&env, "refund_14"),
-            15 => String::from_str(&env, "refund_15"),
-            16 => String::from_str(&env, "refund_16"),
-            17 => String::from_str(&env, "refund_17"),
-            18 => String::from_str(&env, "refund_18"),
-            19 => String::from_str(&env, "refund_19"),
-            20 => String::from_str(&env, "refund_20"),
-            _ => {
-                // For numbers > 20, construct manually using bytes
-                let prefix = bytes!(&env, 0x726566756e645f); // "refund_" in ASCII hex
-                let mut result = Bytes::new(&env);
-                result.append(&prefix);
-
-                // Convert number to ASCII digits (collect in reverse, then reverse)
-                let mut temp = Bytes::new(&env);
-                let mut n = counter;
-                loop {
-                    temp.push_back((n % 10) as u8 + 48); // 48 is ASCII '0'
-                    n /= 10;
-                    if n == 0 {
-                        break;
-                    }
-                }
-                // Reverse the digits
-                let len = temp.len();
-                for i in 0..len {
-                    result.push_back(temp.get(len - 1 - i).unwrap());
-                }
-
-                // Convert bytes to string using a fixed-size array
-                // We know refund IDs won't exceed 64 bytes
-                let mut arr = [0u8; 64];
-                for i in 0..result.len().min(64) {
-                    arr[i as usize] = result.get(i).unwrap();
-                }
-                String::from_bytes(&env, &arr[..result.len() as usize])
-            }
-        };
+        let refund_id = format_id(&env, "refund_", counter);
 
         let refund = Refund {
             refund_id: refund_id.clone(),
@@ -504,44 +453,9 @@ impl RefundManager {
     }
 
     fn build_dispute_id(env: &Env, counter: u64) -> String {
-        match counter {
-            1 => String::from_str(env, "dispute_1"),
-            2 => String::from_str(env, "dispute_2"),
-            3 => String::from_str(env, "dispute_3"),
-            4 => String::from_str(env, "dispute_4"),
-            5 => String::from_str(env, "dispute_5"),
-            6 => String::from_str(env, "dispute_6"),
-            7 => String::from_str(env, "dispute_7"),
-            8 => String::from_str(env, "dispute_8"),
-            9 => String::from_str(env, "dispute_9"),
-            10 => String::from_str(env, "dispute_10"),
-            _ => {
-                let prefix = bytes!(env, 0x646973707574655f); // "dispute_" in ASCII hex
-                let mut result = Bytes::new(env);
-                result.append(&prefix);
-
-                let mut temp = Bytes::new(env);
-                let mut n = counter;
-                loop {
-                    temp.push_back((n % 10) as u8 + 48);
-                    n /= 10;
-                    if n == 0 {
-                        break;
-                    }
-                }
-                let len = temp.len();
-                for i in 0..len {
-                    result.push_back(temp.get(len - 1 - i).unwrap());
-                }
-
-                let mut arr = [0u8; 64];
-                for i in 0..result.len().min(64) {
-                    arr[i as usize] = result.get(i).unwrap();
-                }
-                String::from_bytes(env, &arr[..result.len() as usize])
-            }
-        }
+        format_id(env, "dispute_", counter)
     }
+
 
     fn get_dispute_internal(env: &Env, dispute_id: &String) -> Result<Dispute, Error> {
         env.storage()
@@ -763,5 +677,36 @@ pub mod merchant_registry;
 mod merchant_registry_test;
 #[cfg(test)]
 mod integration_test;
+#[cfg(test)]
 mod auth_test;
+#[cfg(test)]
+mod proptests;
 mod test;
+
+pub fn format_id(env: &Env, prefix: &str, n: u64) -> String {
+    let mut result = Bytes::new(env);
+    for byte in prefix.as_bytes() {
+        result.push_back(*byte);
+    }
+
+    let mut temp = Bytes::new(env);
+    let mut num = n;
+    loop {
+        temp.push_back((num % 10) as u8 + 48);
+        num /= 10;
+        if num == 0 {
+            break;
+        }
+    }
+    let len = temp.len();
+    for i in 0..len {
+        result.push_back(temp.get(len - i - 1).unwrap());
+    }
+
+    let mut arr = [0u8; 64];
+    let final_len = result.len().min(64);
+    for i in 0..final_len {
+        arr[i as usize] = result.get(i).unwrap();
+    }
+    String::from_bytes(env, &arr[..final_len as usize])
+}

--- a/fluxapay/src/proptests.rs
+++ b/fluxapay/src/proptests.rs
@@ -1,0 +1,50 @@
+#![cfg(test)]
+
+use crate::format_id;
+use soroban_sdk::{Env};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_format_id_starts_with_prefix(n in 0u64..u64::MAX) {
+        let env = Env::default();
+        let prefix = "refund_";
+        let id = format_id(&env, prefix, n);
+        
+        let mut arr = [0u8; 64];
+        let len = id.len() as usize;
+        id.copy_into_slice(&mut arr[..len]);
+        let id_str = core::str::from_utf8(&arr[..len]).unwrap();
+        
+        assert!(id_str.starts_with(prefix));
+    }
+
+    #[test]
+    fn test_format_id_uniqueness(n1 in 0u64..u64::MAX, n2 in 0u64..u64::MAX) {
+        prop_assume!(n1 != n2);
+        let env = Env::default();
+        let prefix = "id_";
+        let id1 = format_id(&env, prefix, n1);
+        let id2 = format_id(&env, prefix, n2);
+        
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_format_id_round_trip(n in 1u64..u64::MAX) {
+        let env = Env::default();
+        let prefix = "dispute_";
+        let id = format_id(&env, prefix, n);
+        
+        let mut arr = [0u8; 64];
+        let len = id.len() as usize;
+        id.copy_into_slice(&mut arr[..len]);
+        let id_str = core::str::from_utf8(&arr[..len]).unwrap();
+        
+        // Extract the number part
+        let num_part = &id_str[prefix.len()..];
+        let parsed_n: u64 = num_part.parse().unwrap();
+        
+        assert_eq!(n, parsed_n);
+    }
+}


### PR DESCRIPTION
## Overview
This PR implements property-based testing for the ID generation logic used in refunds and disputes. It refactors the ID formatting into a generic [format_id](cci:1://file:///home/edohwares/Desktop/Room/drips/fluxapay_contract/fluxapay/src/lib.rs:685:0-711:1) utility and uses `proptest` to ensure correctness across the entire range of `u64` values.

## Changes
- **Refactoring**: Consolidated duplicate ID generation logic from [RefundManager](cci:2://file:///home/edohwares/Desktop/Room/drips/fluxapay_contract/fluxapay/src/lib.rs:13:0-13:25) and [Dispute](cci:2://file:///home/edohwares/Desktop/Room/drips/fluxapay_contract/fluxapay/src/lib.rs:73:0-85:1) into a single, testable [format_id](cci:1://file:///home/edohwares/Desktop/Room/drips/fluxapay_contract/fluxapay/src/lib.rs:685:0-711:1) function.
- **Dependency**: Added `proptest` as a dev-dependency.
- **Property Testing**: 
  - Created [fluxapay/src/proptests.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/fluxapay_contract/fluxapay/src/proptests.rs:0:0-0:0) to verify ID prefix consistency, uniqueness, and round-trip numeric accuracy.
  - These tests ensure the byte-reversal algorithm correctly handles all input values from `0` to `u64::MAX`.
- **Bug Fixes**: Resolved compilation issues in existing integration and dispute tests to keep the codebase healthy after recent upstream syncs.

## Verification
Run the new property tests:
`cargo test -p fluxapay proptests`

Closes #44 