### PR TITLE
feat(refund): add payment registration and refund validation

### DIFF
--- a/fluxapay/src/auth_test.rs
+++ b/fluxapay/src/auth_test.rs
@@ -120,6 +120,8 @@ fn test_verify_merchant_called_by_non_admin() {
         &merchant,
         &String::from_str(&env, "M"),
         &String::from_str(&env, "USD"),
+        &None::<Address>,
+        &None::<String>,
     );
     merchant_client.verify_merchant(&non_admin, &merchant);
 }

--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -156,6 +156,9 @@ fn test_resolve_dispute_with_refund() {
     payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
     payment_client.verify_payment(&oracle, &payment_id, &transaction_hash, &customer, &amount);
 
+    // Register payment with refund manager for amount validation
+    refund_client.register_payment(&payment_id, &merchant, &amount, &Symbol::new(&env, "USDC"));
+
     // Create dispute
     let dispute_reason = String::from_str(&env, "Defective product");
     let evidence = String::from_str(&env, "Video evidence of defect");
@@ -353,6 +356,9 @@ fn test_resolve_dispute_with_only_operator_auth() {
     payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
     let tx_hash = BytesN::<32>::random(&env);
     payment_client.verify_payment(&oracle, &payment_id, &tx_hash, &customer, &amount);
+
+    // Register payment with refund manager for amount validation
+    refund_client.register_payment(&payment_id, &merchant, &amount, &Symbol::new(&env, "USDC"));
 
     let dispute_id = refund_client.create_dispute(
         &payment_id,

--- a/fluxapay/src/integration_test.rs
+++ b/fluxapay/src/integration_test.rs
@@ -53,6 +53,8 @@ fn test_happy_path_flow() {
         &merchant,
         &String::from_str(&env, "Flux Merchant"),
         &String::from_str(&env, "USD"),
+        &None::<Address>,
+        &None::<String>,
     );
     merchant_client.verify_merchant(&admin, &merchant);
     let merchant_info = merchant_client.get_merchant(&merchant);
@@ -79,6 +81,9 @@ fn test_happy_path_flow() {
 
     let payment_info = payment_client.get_payment(&payment_id);
     assert_eq!(payment_info.status, PaymentStatus::Confirmed);
+
+    // Register payment with refund manager for amount validation
+    refund_client.register_payment(&payment_id, &merchant, &amount, &Symbol::new(&env, "USDC"));
 
     // 3. Create Dispute and Resolve with Refund
     let dispute_id = refund_client.create_dispute(

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -105,6 +105,7 @@ pub enum Error {
     Unauthorized = 10,
     DisputeNotFound = 11,
     DisputeAlreadyResolved = 12,
+    RefundExceedsPayment = 13,
 }
 
 #[contracttype]
@@ -178,6 +179,38 @@ impl RefundManager {
         AccessControl::get_role_members(&env, &role)
     }
 
+    /// Register a payment with the refund manager so refund amounts can be validated.
+    pub fn register_payment(
+        env: Env,
+        payment_id: String,
+        merchant_id: Address,
+        amount: i128,
+        currency: Symbol,
+    ) {
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::Payment(payment_id.clone()))
+        {
+            let payment = PaymentCharge {
+                payment_id: payment_id.clone(),
+                merchant_id,
+                amount,
+                currency,
+                deposit_address: env.current_contract_address(),
+                status: PaymentStatus::Pending,
+                payer_address: None,
+                transaction_hash: None,
+                created_at: env.ledger().timestamp(),
+                confirmed_at: None,
+                expires_at: 0,
+            };
+            env.storage()
+                .persistent()
+                .set(&DataKey::Payment(payment_id), &payment);
+        }
+    }
+
     pub fn create_refund(
         env: Env,
         payment_id: String,
@@ -198,6 +231,28 @@ impl RefundManager {
     ) -> Result<String, Error> {
         if refund_amount <= 0 {
             return Err(Error::InvalidAmount);
+        }
+
+        // Validate refund amount does not exceed original payment amount
+        let payment: PaymentCharge = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Payment(payment_id.clone()))
+            .ok_or(Error::PaymentNotFound)?;
+
+        // Sum existing refund amounts for this payment
+        let existing_refunds = Self::get_payment_refunds_internal(env, &payment_id);
+        let mut total_refunded: i128 = 0;
+        for id in existing_refunds.iter() {
+            if let Ok(r) = Self::get_refund_internal(env, &id) {
+                if r.status != RefundStatus::Rejected {
+                    total_refunded += r.amount;
+                }
+            }
+        }
+
+        if total_refunded + refund_amount > payment.amount {
+            return Err(Error::RefundExceedsPayment);
         }
 
         let counter = Self::get_next_refund_id(&env);

--- a/fluxapay/src/merchant_registry.rs
+++ b/fluxapay/src/merchant_registry.rs
@@ -20,6 +20,10 @@ pub struct Merchant {
     pub merchant_id: Address,
     pub business_name: String,
     pub settlement_currency: String,
+    /// On-chain address where settled funds are sent.
+    pub payout_address: Option<Address>,
+    /// Off-chain bank account reference for fiat payouts.
+    pub bank_account: Option<String>,
     /// KYC tier replaces the old `verified: bool` field.
     pub kyc_tier: KycTier,
     pub active: bool,
@@ -60,6 +64,8 @@ impl MerchantRegistry {
         merchant_id: Address,
         business_name: String,
         settlement_currency: String,
+        payout_address: Option<Address>,
+        bank_account: Option<String>,
     ) -> Result<(), Error> {
         merchant_id.require_auth();
 
@@ -75,6 +81,8 @@ impl MerchantRegistry {
             merchant_id: merchant_id.clone(),
             business_name,
             settlement_currency,
+            payout_address,
+            bank_account,
             kyc_tier: KycTier::Unverified,
             active: true,
             created_at: env.ledger().timestamp(),
@@ -94,6 +102,8 @@ impl MerchantRegistry {
         business_name: Option<String>,
         settlement_currency: Option<String>,
         active: Option<bool>,
+        payout_address: Option<Address>,
+        bank_account: Option<String>,
     ) -> Result<(), Error> {
         merchant_id.require_auth();
 
@@ -107,6 +117,12 @@ impl MerchantRegistry {
         }
         if let Some(is_active) = active {
             merchant.active = is_active;
+        }
+        if let Some(addr) = payout_address {
+            merchant.payout_address = Some(addr);
+        }
+        if let Some(acct) = bank_account {
+            merchant.bank_account = Some(acct);
         }
 
         env.storage()

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -14,13 +14,25 @@ fn test_merchant_registration() {
     let business_name = String::from_str(&env, "Test Merchant");
     let settlement_currency = String::from_str(&env, "USDC");
 
-    client.register_merchant(&merchant_id, &business_name, &settlement_currency);
+    let payout_addr = Address::generate(&env);
+    client.register_merchant(
+        &merchant_id,
+        &business_name,
+        &settlement_currency,
+        &Some(payout_addr.clone()),
+        &Some(String::from_str(&env, "BANK-001")),
+    );
 
     let merchant = client.get_merchant(&merchant_id);
 
     assert_eq!(merchant.merchant_id, merchant_id);
     assert_eq!(merchant.business_name, business_name);
     assert_eq!(merchant.settlement_currency, settlement_currency);
+    assert_eq!(merchant.payout_address, Some(payout_addr));
+    assert_eq!(
+        merchant.bank_account,
+        Some(String::from_str(&env, "BANK-001"))
+    );
     // New: kyc_tier starts as Unverified
     assert_eq!(merchant.kyc_tier, KycTier::Unverified);
     assert!(merchant.active);
@@ -39,16 +51,25 @@ fn test_merchant_update() {
     let business_name = String::from_str(&env, "Initial name");
     let settlement_currency = String::from_str(&env, "USD");
 
-    client.register_merchant(&merchant_id, &business_name, &settlement_currency);
+    client.register_merchant(
+        &merchant_id,
+        &business_name,
+        &settlement_currency,
+        &None::<Address>,
+        &None::<String>,
+    );
 
     let new_name = String::from_str(&env, "New name");
     let new_currency = String::from_str(&env, "EUR");
+    let new_payout = Address::generate(&env);
 
     client.update_merchant(
         &merchant_id,
         &Some(new_name.clone()),
         &Some(new_currency.clone()),
         &Some(false),
+        &Some(new_payout.clone()),
+        &Some(String::from_str(&env, "BANK-002")),
     );
 
     let updated_merchant = client.get_merchant(&merchant_id);
@@ -56,6 +77,11 @@ fn test_merchant_update() {
     assert_eq!(updated_merchant.business_name, new_name);
     assert_eq!(updated_merchant.settlement_currency, new_currency);
     assert!(!updated_merchant.active);
+    assert_eq!(updated_merchant.payout_address, Some(new_payout));
+    assert_eq!(
+        updated_merchant.bank_account,
+        Some(String::from_str(&env, "BANK-002"))
+    );
 }
 
 #[test]
@@ -75,6 +101,8 @@ fn test_merchant_verification() {
         &merchant_id,
         &String::from_str(&env, "Merchant"),
         &String::from_str(&env, "USDC"),
+        &None::<Address>,
+        &None::<String>,
     );
 
     // verify_merchant sets KycTier::Basic for backward compatibility
@@ -103,6 +131,8 @@ fn test_unauthorized_verification() {
         &merchant_id,
         &String::from_str(&env, "Merchant"),
         &String::from_str(&env, "USDC"),
+        &None::<Address>,
+        &None::<String>,
     );
 
     // Attacker tries to verify the merchant
@@ -125,6 +155,8 @@ fn test_set_kyc_tier() {
         &merchant_id,
         &String::from_str(&env, "BigCorp"),
         &String::from_str(&env, "USDC"),
+        &None::<Address>,
+        &None::<String>,
     );
 
     // Promote through tiers
@@ -156,6 +188,8 @@ fn test_set_kyc_tier_unauthorized() {
         &merchant_id,
         &String::from_str(&env, "Merchant"),
         &String::from_str(&env, "USDC"),
+        &None::<Address>,
+        &None::<String>,
     );
 
     // Non-admin tries to set KYC tier

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -208,9 +208,13 @@ fn test_create_and_get_refund() {
     let (_, client) = setup_refund_manager(&env);
 
     let payment_id = String::from_str(&env, "payment_123");
+    let merchant_id = Address::generate(&env);
     let refund_amount = 1000i128;
     let reason = String::from_str(&env, "Reason");
     let requester = Address::generate(&env);
+
+    // Register payment so refund amount can be validated
+    client.register_payment(&payment_id, &merchant_id, &5000i128, &Symbol::new(&env, "USDC"));
 
     let refund_id = client.create_refund(&payment_id, &refund_amount, &reason, &requester);
     let refund = client.get_refund(&refund_id);
@@ -227,8 +231,12 @@ fn test_process_refund() {
     let (admin, client) = setup_refund_manager(&env);
 
     let payment_id = String::from_str(&env, "payment_123");
+    let merchant_id = Address::generate(&env);
     let refund_amount = 1000i128;
     let requester = Address::generate(&env);
+
+    client.register_payment(&payment_id, &merchant_id, &5000i128, &Symbol::new(&env, "USDC"));
+
     let refund_id = client.create_refund(
         &payment_id,
         &refund_amount,
@@ -292,7 +300,10 @@ fn test_multiple_refunds_unique_ids() {
     let (_, client) = setup_refund_manager(&env);
 
     let payment_id = String::from_str(&env, "payment_123");
+    let merchant_id = Address::generate(&env);
     let requester = Address::generate(&env);
+
+    client.register_payment(&payment_id, &merchant_id, &5000i128, &Symbol::new(&env, "USDC"));
 
     // Create first refund
     let refund_id_1 = client.create_refund(
@@ -345,7 +356,10 @@ fn test_create_refund_requires_auth() {
     let (_, client) = setup_refund_manager(&env);
 
     let payment_id = String::from_str(&env, "payment_123");
+    let merchant_id = Address::generate(&env);
     let requester = Address::generate(&env);
+
+    client.register_payment(&payment_id, &merchant_id, &5000i128, &Symbol::new(&env, "USDC"));
 
     // This should panic because we're not mocking auth
     client.create_refund(


### PR DESCRIPTION
- Add RefundExceedsPayment error variant to prevent refunds exceeding original payment amount
- Implement register_payment method to store payment details in refund manager for validation
- Add refund amount validation logic that sums existing refunds and ensures total doesn't exceed original payment
- Extend Merchant struct with optional payout_address and bank_account fields for settlement routing
- Update register_merchant and update_merchant methods to accept and store payout and bank account details
- Update all test files to pass new optional merchant fields (payout_address, bank_account)
- Add payment registration calls in integration and dispute tests before creating disputes
- Ensures refund operations have complete payment context for accurate amount validation

**Task Completed**

- Closes #24 
- Closes #34 
- Closes #30 
- Closes #25 