### PR TITLE
feat: add 1% refund fee sent to contract admin

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -161,6 +161,8 @@ const LONG_LIVE_TTL: u32 = 18_921_600; // ~3 years at 5s/ledger
 const TTL_BUMP_THRESHOLD_DIVISOR: u32 = 5;
 const CREATE_PAYMENT_WINDOW_SECS: u64 = 60;
 const CREATE_PAYMENT_MAX_PER_WINDOW: u32 = 30;
+/// 1% refund fee in basis points (100 bps = 1%).
+const REFUND_FEE_BPS: i128 = 100;
 
 #[contractimpl]
 #[allow(deprecated)] // events::publish — migrate to #[contractevent] in a follow-up
@@ -387,13 +389,21 @@ impl RefundManager {
             .ok_or(Error::Unauthorized)?;
         let token_client = token::TokenClient::new(env, &usdc_token_address);
 
+        let fee = refund.amount * REFUND_FEE_BPS / 10_000;
+        let net_amount = refund.amount - fee;
+
         let from = env.current_contract_address();
         let to: MuxedAddress = (&refund.requester).into();
-        if token_client
-            .try_transfer(&from, &to, &refund.amount)
-            .is_err()
-        {
+        if token_client.try_transfer(&from, &to, &net_amount).is_err() {
             return Ok(());
+        }
+
+        // Transfer fee to admin
+        if fee > 0 {
+            if let Some(admin) = AccessControl::get_admin(env) {
+                let admin_muxed: MuxedAddress = (&admin).into();
+                let _ = token_client.try_transfer(&from, &admin_muxed, &fee);
+            }
         }
 
         refund.status = RefundStatus::Completed;

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -769,3 +769,66 @@ fn test_admin_in_role_members_after_init() {
     assert_eq!(members.len(), 1);
     assert_eq!(members.get(0), Some(admin));
 }
+
+fn setup_refund_manager_with_token(env: &Env) -> (Address, RefundManagerClient<'_>, Address) {
+    let contract_id = env.register(RefundManager, ());
+    let client = RefundManagerClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let usdc_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.initialize_refund_manager(&admin, &usdc_token);
+    let token_admin_client = token::StellarAssetClient::new(env, &usdc_token);
+    token_admin_client.mint(&contract_id, &1_000_000_000_000i128);
+    (admin, client, usdc_token)
+}
+
+#[test]
+fn test_process_refund_deducts_fee_from_requester() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client, usdc_token) = setup_refund_manager_with_token(&env);
+
+    let payment_id = String::from_str(&env, "payment_fee_1");
+    let merchant_id = Address::generate(&env);
+    let refund_amount = 10_000i128;
+    let requester = Address::generate(&env);
+
+    client.register_payment(&payment_id, &merchant_id, &refund_amount, &Symbol::new(&env, "USDC"));
+    let refund_id = client.create_refund(&payment_id, &refund_amount, &String::from_str(&env, "fee test"), &requester);
+
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_settlement_operator(&env), &operator);
+    client.process_refund(&operator, &refund_id);
+
+    let token_client = token::TokenClient::new(&env, &usdc_token);
+    let fee = refund_amount * 100 / 10_000; // 1%
+    let net = refund_amount - fee;
+
+    assert_eq!(token_client.balance(&requester), net);
+}
+
+#[test]
+fn test_process_refund_sends_fee_to_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client, usdc_token) = setup_refund_manager_with_token(&env);
+
+    let payment_id = String::from_str(&env, "payment_fee_2");
+    let merchant_id = Address::generate(&env);
+    let refund_amount = 10_000i128;
+    let requester = Address::generate(&env);
+
+    client.register_payment(&payment_id, &merchant_id, &refund_amount, &Symbol::new(&env, "USDC"));
+    let refund_id = client.create_refund(&payment_id, &refund_amount, &String::from_str(&env, "fee test"), &requester);
+
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_settlement_operator(&env), &operator);
+    client.process_refund(&operator, &refund_id);
+
+    let token_client = token::TokenClient::new(&env, &usdc_token);
+    let fee = refund_amount * 100 / 10_000; // 1%
+
+    assert_eq!(token_client.balance(&admin), fee);
+}


### PR DESCRIPTION
i Add REFUND_FEE_BPS = 100 constant (1% in basis points)
- Deduct fee from refund amount before transferring to requester
- Transfer fee to contract admin (best-effort)
- Add tests for fee deduction and admin fee receipt
closes #117 