### PR TITLE
feat: multi-asset payments, amount limits, configurable payment expir…

### DIFF
--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -50,9 +50,11 @@ fn test_create_dispute() {
         &amount,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     // Verify payment
@@ -107,9 +109,11 @@ fn test_review_dispute() {
         &amount,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let transaction_hash = BytesN::<32>::random(&env);
@@ -163,9 +167,11 @@ fn test_resolve_dispute_with_refund() {
         &amount,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let transaction_hash = BytesN::<32>::random(&env);
@@ -229,9 +235,11 @@ fn test_reject_dispute() {
         &amount,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let transaction_hash = BytesN::<32>::random(&env);
@@ -283,9 +291,11 @@ fn test_get_payment_disputes() {
         &amount,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let transaction_hash = BytesN::<32>::random(&env);
@@ -342,9 +352,11 @@ fn test_dispute_invalid_amount() {
         &amount,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     // Try to create dispute with invalid amount - should fail
@@ -382,9 +394,11 @@ fn test_resolve_dispute_with_only_operator_auth() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &merchant,
-        &(env.ledger().timestamp() + 3600),
+        &Some(env.ledger().timestamp() + 3600),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let oracle = Address::generate(&env);

--- a/fluxapay/src/integration_test.rs
+++ b/fluxapay/src/integration_test.rs
@@ -72,9 +72,11 @@ fn test_happy_path_flow() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let tx_hash = BytesN::<32>::random(&env);
@@ -136,9 +138,11 @@ fn test_settlement_path() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &(env.ledger().timestamp() + 3600),
+        &Some(env.ledger().timestamp() + 3600),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let oracle = Address::generate(&env);
@@ -178,9 +182,11 @@ fn test_failure_and_expiration_path() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     // Jump forward in time

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -41,6 +41,8 @@ pub struct PaymentCharge {
     pub memo: Option<String>,
     /// Optional memo type: Text, Id, Hash, or Return.
     pub memo_type: Option<String>,
+    /// Token contract address used for this payment (None defaults to the configured USDC token).
+    pub token_address: Option<Address>,
 }
 
 #[contracttype]
@@ -132,6 +134,10 @@ pub enum Error {
     ContractPaused = 17,
     RateLimitExceeded = 18,
     RefundCancelled = 19,
+    UnsupportedToken = 20,
+    AmountBelowMin = 21,
+    AmountAboveMax = 22,
+    InvalidExpiry = 23,
 }
 
 #[contracttype]
@@ -139,6 +145,13 @@ pub enum Error {
 pub struct MerchantCreateRateLimit {
     pub last_payment_at: u64,
     pub count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AmountLimits {
+    pub min: Option<i128>,
+    pub max: Option<i128>,
 }
 
 #[contracttype]
@@ -155,6 +168,9 @@ pub enum DataKey {
     UsdcToken,
     Paused,
     MerchantRegistryAddress,
+    AllowedToken(Address),
+    MerchantAmountLimits(Address),
+    GlobalAmountLimits,
 }
 
 const SHORT_LIVE_TTL: u32 = 120_960; // ~1 week at 5s/ledger
@@ -162,6 +178,8 @@ const LONG_LIVE_TTL: u32 = 18_921_600; // ~3 years at 5s/ledger
 const TTL_BUMP_THRESHOLD_DIVISOR: u32 = 5;
 const CREATE_PAYMENT_WINDOW_SECS: u64 = 60;
 const CREATE_PAYMENT_MAX_PER_WINDOW: u32 = 30;
+/// Default payment validity window: 1 hour.
+pub const DEFAULT_PAYMENT_DURATION_SECS: u64 = 3_600;
 /// 1% refund fee in basis points (100 bps = 1%).
 const REFUND_FEE_BPS: i128 = 100;
 
@@ -252,6 +270,7 @@ impl RefundManager {
                 amount_received: None,
                 memo: None,
                 memo_type: None,
+                token_address: None,
             };
             env.storage()
                 .persistent()
@@ -1040,6 +1059,115 @@ impl PaymentProcessor {
         Ok(())
     }
 
+    /// Set per-merchant min/max payment amount limits (merchant self-service).
+    /// Pass None to clear a bound. Requires the caller to hold the MERCHANT role.
+    pub fn set_merchant_amount_limits(
+        env: Env,
+        merchant_id: Address,
+        min: Option<i128>,
+        max: Option<i128>,
+    ) -> Result<(), Error> {
+        merchant_id.require_auth();
+        if !AccessControl::has_role(&env, &role_merchant(&env), &merchant_id) {
+            return Err(Error::Unauthorized);
+        }
+        if let (Some(lo), Some(hi)) = (min, max) {
+            if lo > hi {
+                return Err(Error::InvalidAmount);
+            }
+        }
+        let limits = AmountLimits { min, max };
+        env.storage()
+            .persistent()
+            .set(&DataKey::MerchantAmountLimits(merchant_id), &limits);
+        Ok(())
+    }
+
+    /// Read per-merchant amount limits.
+    pub fn get_merchant_amount_limits(env: Env, merchant_id: Address) -> Option<AmountLimits> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MerchantAmountLimits(merchant_id))
+    }
+
+    /// Set global min/max payment amount limits (admin only).
+    /// Pass None to clear a bound.
+    pub fn set_global_amount_limits(
+        env: Env,
+        admin: Address,
+        min: Option<i128>,
+        max: Option<i128>,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        if let (Some(lo), Some(hi)) = (min, max) {
+            if lo > hi {
+                return Err(Error::InvalidAmount);
+            }
+        }
+        let limits = AmountLimits { min, max };
+        env.storage()
+            .persistent()
+            .set(&DataKey::GlobalAmountLimits, &limits);
+        Ok(())
+    }
+
+    /// Read global amount limits.
+    pub fn get_global_amount_limits(env: Env) -> Option<AmountLimits> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::GlobalAmountLimits)
+    }
+
+    /// Enforce amount limits: merchant-specific limits take precedence over global limits.
+    fn enforce_amount_limits(env: &Env, merchant_id: &Address, amount: i128) -> Result<(), Error> {
+        let limits: Option<AmountLimits> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MerchantAmountLimits(merchant_id.clone()))
+            .or_else(|| {
+                env.storage()
+                    .persistent()
+                    .get(&DataKey::GlobalAmountLimits)
+            });
+
+        if let Some(l) = limits {
+            if let Some(min) = l.min {
+                if amount < min {
+                    return Err(Error::AmountBelowMin);
+                }
+            }
+            if let Some(max) = l.max {
+                if amount > max {
+                    return Err(Error::AmountAboveMax);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Allow or disallow a token address for use in payments (admin only).
+    pub fn allow_token(env: Env, admin: Address, token_address: Address) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllowedToken(token_address), &true);
+        Ok(())
+    }
+
+    /// Returns true if the given token address is on the allowlist.
+    pub fn is_token_allowed(env: Env, token_address: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::AllowedToken(token_address))
+            .unwrap_or(false)
+    }
+
     #[allow(deprecated)]
     #[allow(clippy::too_many_arguments)]
     pub fn create_payment(
@@ -1049,9 +1177,14 @@ impl PaymentProcessor {
         amount: i128,
         currency: Symbol,
         deposit_address: Address,
-        expires_at: u64,
+        /// Absolute expiry timestamp (Unix seconds). When `None`, `duration_secs` is used.
+        expires_at: Option<u64>,
+        /// Seconds from now until the payment expires. Ignored when `expires_at` is `Some`.
+        /// Defaults to `DEFAULT_PAYMENT_DURATION_SECS` (1 hour) when both are `None`.
+        duration_secs: Option<u64>,
         memo: Option<String>,
         memo_type: Option<String>,
+        token_address: Option<Address>,
     ) -> Result<PaymentCharge, Error> {
         Self::require_not_paused(&env)?;
         merchant_id.require_auth();
@@ -1059,6 +1192,18 @@ impl PaymentProcessor {
         // Verify that the merchant has the MERCHANT role (granted on verification)
         if !AccessControl::has_role(&env, &role_merchant(&env), &merchant_id) {
             return Err(Error::Unauthorized);
+        }
+
+        // Validate token: if provided it must be on the allowlist; if absent the default USDC token is used.
+        if let Some(ref token_addr) = token_address {
+            let allowed: bool = env
+                .storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::AllowedToken(token_addr.clone()))
+                .unwrap_or(false);
+            if !allowed {
+                return Err(Error::UnsupportedToken);
+            }
         }
 
         // Issue #79: Cross-contract validate merchant is verified and active
@@ -1087,6 +1232,8 @@ impl PaymentProcessor {
             return Err(Error::InvalidAmount);
         }
 
+        Self::enforce_amount_limits(&env, &merchant_id, amount)?;
+
         if env
             .storage()
             .persistent()
@@ -1101,6 +1248,17 @@ impl PaymentProcessor {
 
         Self::enforce_create_payment_rate_limit(&env, &merchant_id)?;
 
+        let now = env.ledger().timestamp();
+        let resolved_expires_at = match expires_at {
+            Some(ts) => ts,
+            None => now.saturating_add(
+                duration_secs.unwrap_or(DEFAULT_PAYMENT_DURATION_SECS),
+            ),
+        };
+        if resolved_expires_at <= now {
+            return Err(Error::InvalidExpiry);
+        }
+
         let payment = PaymentCharge {
             payment_id: payment_id.clone(),
             merchant_id: merchant_id.clone(),
@@ -1110,12 +1268,13 @@ impl PaymentProcessor {
             status: PaymentStatus::Pending,
             payer_address: None,
             transaction_hash: None,
-            created_at: env.ledger().timestamp(),
+            created_at: now,
             confirmed_at: None,
-            expires_at,
+            expires_at: resolved_expires_at,
             amount_received: None,
             memo: memo.clone(),
             memo_type: memo_type.clone(),
+            token_address: token_address.clone(),
         };
 
         env.storage()
@@ -1182,15 +1341,37 @@ impl PaymentProcessor {
         payment.transaction_hash = Some(transaction_hash);
         payment.confirmed_at = Some(env.ledger().timestamp());
 
+        // Scale tolerance by token decimals: 1 unit in the smallest denomination per decimal place.
+        // USDC has 7 decimals on Stellar (stroops); other tokens may differ.
+        // tolerance = 10^(decimals - 6) clamped to at least 1, so a 6-decimal token gets tolerance=1,
+        // a 7-decimal token gets tolerance=10, a 2-decimal token gets tolerance=1 (clamped).
+        let tolerance = if let Some(ref token_addr) = payment.token_address {
+            let decimals = token::TokenClient::new(&env, token_addr).decimals();
+            if decimals >= 6 {
+                let exp = (decimals - 6) as u32;
+                let mut t: i128 = 1;
+                let mut i = 0u32;
+                while i < exp {
+                    t *= 10;
+                    i += 1;
+                }
+                t
+            } else {
+                1i128
+            }
+        } else {
+            PAYMENT_TOLERANCE
+        };
+
         let diff = amount_received - payment.amount;
 
-        let new_status = if (0..=PAYMENT_TOLERANCE).contains(&diff) {
+        let new_status = if (0..=tolerance).contains(&diff) {
             // Exact match or tiny overpay within tolerance → Confirmed
             PaymentStatus::Confirmed
-        } else if diff > PAYMENT_TOLERANCE {
+        } else if diff > tolerance {
             // Meaningfully more than expected → Overpaid
             PaymentStatus::Overpaid
-        } else if diff >= -PAYMENT_TOLERANCE {
+        } else if diff >= -tolerance {
             // Tiny underpay within tolerance → Confirmed
             PaymentStatus::Confirmed
         } else {

--- a/fluxapay/src/memo_test.rs
+++ b/fluxapay/src/memo_test.rs
@@ -34,9 +34,11 @@ fn test_create_payment_with_memo() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+        &None::<u64>,
         &memo,
-        &memo_type,
+            &memo_type,
+    &None::<Address>,
     );
 
     assert_eq!(payment.payment_id, payment_id);
@@ -63,9 +65,11 @@ fn test_create_payment_without_memo() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     assert_eq!(payment.payment_id, payment_id);
@@ -94,9 +98,11 @@ fn test_create_payment_with_id_memo() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+        &None::<u64>,
         &memo,
-        &memo_type,
+            &memo_type,
+    &None::<Address>,
     );
 
     assert_eq!(payment.memo, Some(String::from_str(&env, "123456789")));
@@ -124,9 +130,11 @@ fn test_create_payment_with_hash_memo() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+        &None::<u64>,
         &memo,
-        &memo_type,
+            &memo_type,
+    &None::<Address>,
     );
 
     assert_eq!(
@@ -157,9 +165,11 @@ fn test_memo_persists_after_verification() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+        &None::<u64>,
         &memo,
-        &memo_type,
+            &memo_type,
+    &None::<Address>,
     );
 
     // Verify payment

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -342,9 +342,11 @@ fn test_unverified_merchant_cannot_create_payment() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 }
 
@@ -396,9 +398,11 @@ fn test_verified_merchant_can_create_payment() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     assert_eq!(payment.payment_id, payment_id);

--- a/fluxapay/src/pause_test.rs
+++ b/fluxapay/src/pause_test.rs
@@ -53,9 +53,11 @@ fn test_create_payment_when_paused() {
         &1000i128,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &(env.ledger().timestamp() + 3600),
+        &Some(env.ledger().timestamp() + 3600),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 }
 
@@ -77,9 +79,11 @@ fn test_verify_payment_when_paused() {
         &1000i128,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &(env.ledger().timestamp() + 3600),
+        &Some(env.ledger().timestamp() + 3600),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     // Pause the contract
@@ -115,9 +119,11 @@ fn test_cancel_payment_when_paused() {
         &1000i128,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &(env.ledger().timestamp() + 3600),
+        &Some(env.ledger().timestamp() + 3600),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     // Pause the contract
@@ -148,9 +154,11 @@ fn test_create_payment_after_unpause() {
         &1000i128,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &(env.ledger().timestamp() + 3600),
+        &Some(env.ledger().timestamp() + 3600),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     assert_eq!(payment.status, PaymentStatus::Pending);

--- a/fluxapay/src/proptests.rs
+++ b/fluxapay/src/proptests.rs
@@ -87,9 +87,11 @@ proptest! {
             &amount,
             &Symbol::new(&env, "USDC"),
             &Address::generate(&env),
-            &expires_at,
+            &Some(expires_at),
+                        &None::<u64>,
+                        &None::<String>,
             &None::<String>,
-            &None::<String>,
+            &None::<Address>,
         );
 
         env.ledger().set_timestamp(expires_at + after_expiry);
@@ -131,9 +133,11 @@ proptest! {
             &amount,
             &Symbol::new(&env, "USDC"),
             &Address::generate(&env),
-            &expires_at,
+            &Some(expires_at),
+                        &None::<u64>,
+                        &None::<String>,
             &None::<String>,
-            &None::<String>,
+            &None::<Address>,
         );
 
         let status = client.verify_payment(

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -52,9 +52,11 @@ fn test_create_payment() {
         &amount,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     assert_eq!(payment.payment_id, payment_id);
@@ -88,9 +90,11 @@ fn test_create_payment_rate_limit_enforced() {
             &100i128,
             &currency,
             &deposit_address,
-            &expires_at,
+            &Some(expires_at),
+                        &None::<u64>,
+                        &None::<String>,
             &None::<String>,
-            &None::<String>,
+            &None::<Address>,
         );
     }
 
@@ -101,9 +105,11 @@ fn test_create_payment_rate_limit_enforced() {
         &100i128,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     assert_eq!(overflow, Err(Ok(Error::RateLimitExceeded)));
@@ -127,9 +133,11 @@ fn test_verify_payment_success() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let payer_address = Address::generate(&env);
@@ -169,9 +177,11 @@ fn test_verify_payment_partially_paid() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let oracle = Address::generate(&env);
@@ -211,9 +221,11 @@ fn test_verify_payment_overpaid() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let oracle = Address::generate(&env);
@@ -253,9 +265,11 @@ fn test_verify_payment_within_tolerance() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let oracle = Address::generate(&env);
@@ -299,9 +313,11 @@ fn test_get_merchant_payments_index_and_pagination() {
         &100i128,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
     client.create_payment(
         &payment_id_2,
@@ -309,9 +325,11 @@ fn test_get_merchant_payments_index_and_pagination() {
         &200i128,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
     client.create_payment(
         &payment_id_3,
@@ -319,9 +337,11 @@ fn test_get_merchant_payments_index_and_pagination() {
         &300i128,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let all = client.get_merchant_payments(&merchant_id);
@@ -353,9 +373,11 @@ fn test_cancel_pending_success() {
         &500i128,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     // Set time to before expiry
@@ -392,9 +414,11 @@ fn test_cancel_fails_when_confirmed() {
         &amount,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let oracle = Address::generate(&env);
@@ -429,9 +453,11 @@ fn test_expiry_logic() {
         &500i128,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     // Set time to past expiry
@@ -469,9 +495,11 @@ fn test_unauthorized_cancel() {
         &500i128,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     let random_addr = Address::generate(&env);
@@ -496,9 +524,11 @@ fn test_expire_payment_after_deadline() {
         &500i128,
         &Symbol::new(&env, "USDC"),
         &Address::generate(&env),
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 
     env.ledger().set_timestamp(expires_at + 1);
@@ -718,9 +748,11 @@ fn test_create_payment_requires_auth() {
         &amount,
         &currency,
         &deposit_address,
-        &expires_at,
+        &Some(expires_at),
+                &None::<u64>,
+                &None::<String>,
         &None::<String>,
-        &None::<String>,
+        &None::<Address>,
     );
 }
 
@@ -929,4 +961,635 @@ fn test_cancel_refund_emits_event() {
     let topics = last.1;
     assert_eq!(topics.get(0).unwrap(), Symbol::new(&env, "REFUND").into_val(&env));
     assert_eq!(topics.get(1).unwrap(), Symbol::new(&env, "CANCELLED").into_val(&env));
+}
+
+// --- Payment expiry / duration tests ---
+
+#[test]
+fn test_create_payment_with_explicit_expires_at() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let expires_at = env.ledger().timestamp() + 7200; // 2 hours
+    let payment = client.create_payment(
+        &String::from_str(&env, "pay_explicit_expiry"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(expires_at),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(payment.expires_at, expires_at);
+}
+
+#[test]
+fn test_create_payment_with_duration_secs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let now = env.ledger().timestamp();
+    let duration = 1800u64; // 30 minutes
+    let payment = client.create_payment(
+        &String::from_str(&env, "pay_duration"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &None::<u64>,
+        &Some(duration),
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(payment.expires_at, now + duration);
+}
+
+#[test]
+fn test_create_payment_defaults_to_one_hour() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let now = env.ledger().timestamp();
+    let payment = client.create_payment(
+        &String::from_str(&env, "pay_default_expiry"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &None::<u64>,
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(payment.expires_at, now + DEFAULT_PAYMENT_DURATION_SECS);
+}
+
+#[test]
+fn test_create_payment_explicit_expires_at_overrides_duration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let explicit_ts = env.ledger().timestamp() + 9999;
+    let payment = client.create_payment(
+        &String::from_str(&env, "pay_explicit_wins"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(explicit_ts),
+        &Some(60u64), // duration ignored when expires_at is Some
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(payment.expires_at, explicit_ts);
+}
+
+#[test]
+fn test_create_payment_past_expires_at_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let now = env.ledger().timestamp();
+    // expires_at in the past (or equal to now)
+    let result = client.try_create_payment(
+        &String::from_str(&env, "pay_past_expiry"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(now), // now is not > now, so invalid
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidExpiry)));
+}
+
+#[test]
+fn test_create_payment_zero_duration_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let result = client.try_create_payment(
+        &String::from_str(&env, "pay_zero_duration"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &None::<u64>,
+        &Some(0u64), // 0 seconds → expires_at == now → invalid
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidExpiry)));
+}
+
+// --- Amount limits tests ---
+
+#[test]
+fn test_global_min_limit_blocks_payment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    client.set_global_amount_limits(&admin, &Some(500i128), &None::<i128>);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let result = client.try_create_payment(
+        &String::from_str(&env, "pay_below_global_min"),
+        &merchant_id,
+        &499i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(result, Err(Ok(Error::AmountBelowMin)));
+}
+
+#[test]
+fn test_global_max_limit_blocks_payment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    client.set_global_amount_limits(&admin, &None::<i128>, &Some(1000i128));
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let result = client.try_create_payment(
+        &String::from_str(&env, "pay_above_global_max"),
+        &merchant_id,
+        &1001i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(result, Err(Ok(Error::AmountAboveMax)));
+}
+
+#[test]
+fn test_global_limits_allow_payment_within_range() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    client.set_global_amount_limits(&admin, &Some(100i128), &Some(10_000i128));
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let payment = client.create_payment(
+        &String::from_str(&env, "pay_within_global"),
+        &merchant_id,
+        &5_000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(payment.status, PaymentStatus::Pending);
+}
+
+#[test]
+fn test_merchant_limits_override_global_limits() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    // Global: min 1000
+    client.set_global_amount_limits(&admin, &Some(1000i128), &None::<i128>);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    // Merchant-specific: min 10 (lower than global)
+    client.set_merchant_amount_limits(&merchant_id, &Some(10i128), &None::<i128>);
+
+    // 500 is below global min but above merchant min — should succeed
+    let payment = client.create_payment(
+        &String::from_str(&env, "pay_merchant_override"),
+        &merchant_id,
+        &500i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(payment.status, PaymentStatus::Pending);
+}
+
+#[test]
+fn test_merchant_max_limit_blocks_payment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    client.set_merchant_amount_limits(&merchant_id, &None::<i128>, &Some(200i128));
+
+    let result = client.try_create_payment(
+        &String::from_str(&env, "pay_above_merchant_max"),
+        &merchant_id,
+        &201i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+    assert_eq!(result, Err(Ok(Error::AmountAboveMax)));
+}
+
+#[test]
+fn test_set_merchant_limits_invalid_range_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    // min > max — must fail
+    let result = client.try_set_merchant_amount_limits(
+        &merchant_id,
+        &Some(1000i128),
+        &Some(500i128),
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn test_get_merchant_and_global_limits() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    assert_eq!(client.get_global_amount_limits(), None);
+    assert_eq!(client.get_merchant_amount_limits(&merchant_id), None);
+
+    client.set_global_amount_limits(&admin, &Some(50i128), &Some(5000i128));
+    client.set_merchant_amount_limits(&merchant_id, &Some(100i128), &Some(2000i128));
+
+    let global = client.get_global_amount_limits().unwrap();
+    assert_eq!(global.min, Some(50i128));
+    assert_eq!(global.max, Some(5000i128));
+
+    let merchant = client.get_merchant_amount_limits(&merchant_id).unwrap();
+    assert_eq!(merchant.min, Some(100i128));
+    assert_eq!(merchant.max, Some(2000i128));
+}
+
+// --- Multi-asset payment tests ---
+
+#[test]
+fn test_create_payment_with_allowed_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let token_admin = Address::generate(&env);
+    let alt_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    // Allow the token
+    client.allow_token(&admin, &alt_token);
+    assert!(client.is_token_allowed(&alt_token));
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let payment_id = String::from_str(&env, "pay_alt_token");
+    let payment = client.create_payment(
+        &payment_id,
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "EURC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &Some(alt_token.clone()),
+    );
+
+    assert_eq!(payment.token_address, Some(alt_token));
+    assert_eq!(payment.status, PaymentStatus::Pending);
+}
+
+#[test]
+fn test_create_payment_with_unlisted_token_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let token_admin = Address::generate(&env);
+    let unknown_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    // Do NOT allow the token
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let result = client.try_create_payment(
+        &String::from_str(&env, "pay_bad_token"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "RAND"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &Some(unknown_token),
+    );
+
+    assert_eq!(result, Err(Ok(Error::UnsupportedToken)));
+}
+
+#[test]
+fn test_create_payment_no_token_address_uses_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let payment = client.create_payment(
+        &String::from_str(&env, "pay_default_token"),
+        &merchant_id,
+        &500i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+    );
+
+    assert_eq!(payment.token_address, None);
+    assert_eq!(payment.status, PaymentStatus::Pending);
+}
+
+#[test]
+fn test_verify_payment_decimal_aware_tolerance_7_decimals() {
+    // A token with 7 decimals should have tolerance = 10 (10^(7-6))
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let token_admin = Address::generate(&env);
+    let alt_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    // Stellar asset contracts report 7 decimals
+    client.allow_token(&admin, &alt_token);
+
+    let merchant_id = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+    client.grant_role(&admin, &role_oracle(&env), &oracle);
+
+    let payment_id = String::from_str(&env, "pay_7dec");
+    let amount = 1_000_000_0i128; // 1.0 in 7-decimal units
+    client.create_payment(
+        &payment_id,
+        &merchant_id,
+        &amount,
+        &Symbol::new(&env, "EURC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &Some(alt_token),
+    );
+
+    // Underpay by 10 (within 7-decimal tolerance of 10) → Confirmed
+    let status = client.verify_payment(
+        &oracle,
+        &payment_id,
+        &BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &(amount - 10),
+    );
+    assert_eq!(status, PaymentStatus::Confirmed);
+}
+
+#[test]
+fn test_verify_payment_decimal_aware_tolerance_7_decimals_overpay() {
+    // Underpay by 11 (outside 7-decimal tolerance of 10) → PartiallyPaid
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let token_admin = Address::generate(&env);
+    let alt_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.allow_token(&admin, &alt_token);
+
+    let merchant_id = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+    client.grant_role(&admin, &role_oracle(&env), &oracle);
+
+    let payment_id = String::from_str(&env, "pay_7dec_partial");
+    let amount = 1_000_000_0i128;
+    client.create_payment(
+        &payment_id,
+        &merchant_id,
+        &amount,
+        &Symbol::new(&env, "EURC"),
+        &Address::generate(&env),
+        &Some(env.ledger().timestamp() + 3600),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &Some(alt_token),
+    );
+
+    // Underpay by 11 → PartiallyPaid
+    let status = client.verify_payment(
+        &oracle,
+        &payment_id,
+        &BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &(amount - 11),
+    );
+    assert_eq!(status, PaymentStatus::PartiallyPaid);
+}
+
+// --- Cumulative refund cap tests ---
+
+#[test]
+fn test_cumulative_refunds_exceed_payment_amount_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup_refund_manager(&env);
+
+    let payment_id = String::from_str(&env, "pay_cumulative_1");
+    let merchant_id = Address::generate(&env);
+    let requester = Address::generate(&env);
+    let payment_amount = 1000i128;
+
+    client.register_payment(&payment_id, &merchant_id, &payment_amount, &Symbol::new(&env, "USDC"));
+
+    // First refund: 600 — ok
+    client.create_refund(&payment_id, &600i128, &String::from_str(&env, "partial 1"), &requester);
+
+    // Second refund: 500 — 600 + 500 = 1100 > 1000 — must fail
+    let result = client.try_create_refund(
+        &payment_id,
+        &500i128,
+        &String::from_str(&env, "partial 2"),
+        &requester,
+    );
+    assert_eq!(result, Err(Ok(Error::RefundExceedsPayment)));
+}
+
+#[test]
+fn test_refund_exactly_equal_to_payment_amount_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup_refund_manager(&env);
+
+    let payment_id = String::from_str(&env, "pay_exact_1");
+    let merchant_id = Address::generate(&env);
+    let requester = Address::generate(&env);
+    let payment_amount = 1000i128;
+
+    client.register_payment(&payment_id, &merchant_id, &payment_amount, &Symbol::new(&env, "USDC"));
+
+    // Single refund equal to full payment amount — must succeed
+    let refund_id = client.create_refund(
+        &payment_id,
+        &payment_amount,
+        &String::from_str(&env, "full refund"),
+        &requester,
+    );
+    let refund = client.get_refund(&refund_id);
+    assert_eq!(refund.amount, payment_amount);
+    assert_eq!(refund.status, RefundStatus::Pending);
+}
+
+#[test]
+fn test_second_refund_after_full_refund_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup_refund_manager(&env);
+
+    let payment_id = String::from_str(&env, "pay_full_then_extra");
+    let merchant_id = Address::generate(&env);
+    let requester = Address::generate(&env);
+    let payment_amount = 1000i128;
+
+    client.register_payment(&payment_id, &merchant_id, &payment_amount, &Symbol::new(&env, "USDC"));
+
+    // Full refund — ok
+    client.create_refund(&payment_id, &payment_amount, &String::from_str(&env, "full"), &requester);
+
+    // Any additional refund — must fail
+    let result = client.try_create_refund(
+        &payment_id,
+        &1i128,
+        &String::from_str(&env, "extra"),
+        &requester,
+    );
+    assert_eq!(result, Err(Ok(Error::RefundExceedsPayment)));
+}
+
+#[test]
+fn test_rejected_refunds_not_counted_in_cumulative_total() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_refund_manager(&env);
+
+    let payment_id = String::from_str(&env, "pay_rejected_refund");
+    let merchant_id = Address::generate(&env);
+    let requester = Address::generate(&env);
+    let payment_amount = 1000i128;
+
+    client.register_payment(&payment_id, &merchant_id, &payment_amount, &Symbol::new(&env, "USDC"));
+
+    // Create and reject a refund for 800
+    let refund_id = client.create_refund(
+        &payment_id,
+        &800i128,
+        &String::from_str(&env, "will be rejected"),
+        &requester,
+    );
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_settlement_operator(&env), &operator);
+    client.reject_refund(&operator, &refund_id);
+
+    // A new refund for 1000 should succeed because the rejected one is excluded
+    let new_refund_id = client.create_refund(
+        &payment_id,
+        &payment_amount,
+        &String::from_str(&env, "after rejection"),
+        &requester,
+    );
+    let refund = client.get_refund(&new_refund_id);
+    assert_eq!(refund.amount, payment_amount);
+    assert_eq!(refund.status, RefundStatus::Pending);
 }


### PR DESCRIPTION
…y, cumulative refund cap

- feat(multi-asset): add token_address to PaymentCharge, token allowlist (allow_token/is_token_allowed), UnsupportedToken error, decimal-aware verify_payment tolerance scaled by token decimals

- feat(amount-limits): add AmountLimits struct, per-merchant and global min/max bounds (set/get_merchant_amount_limits, set/get_global_amount_limits), AmountBelowMin/AmountAboveMax errors, enforcement in create_payment

- feat(expiry): make expires_at optional (Option<u64>), add duration_secs (Option<u64>), default to 1 hour (DEFAULT_PAYMENT_DURATION_SECS), InvalidExpiry error when resolved timestamp is not in the future

- fix(refund-cap): create_refund_internal sums non-rejected refunds per payment and returns RefundExceedsPayment when total would exceed payment.amount

- test: add unit tests for all four features across test.rs
closes #102 
closes #104 
closes #105 
closes #106 