### PR TITLE
feat: add client_token idempotency key to create_payment

### DIFF
--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -55,6 +55,7 @@ fn test_create_dispute() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     // Verify payment
@@ -114,6 +115,7 @@ fn test_review_dispute() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let transaction_hash = BytesN::<32>::random(&env);
@@ -172,6 +174,7 @@ fn test_resolve_dispute_with_refund() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let transaction_hash = BytesN::<32>::random(&env);
@@ -240,6 +243,7 @@ fn test_reject_dispute() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let transaction_hash = BytesN::<32>::random(&env);
@@ -296,6 +300,7 @@ fn test_get_payment_disputes() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let transaction_hash = BytesN::<32>::random(&env);
@@ -357,6 +362,7 @@ fn test_dispute_invalid_amount() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     // Try to create dispute with invalid amount - should fail
@@ -399,6 +405,7 @@ fn test_resolve_dispute_with_only_operator_auth() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let oracle = Address::generate(&env);

--- a/fluxapay/src/integration_test.rs
+++ b/fluxapay/src/integration_test.rs
@@ -77,6 +77,7 @@ fn test_happy_path_flow() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let tx_hash = BytesN::<32>::random(&env);
@@ -143,6 +144,7 @@ fn test_settlement_path() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let oracle = Address::generate(&env);
@@ -187,6 +189,7 @@ fn test_failure_and_expiration_path() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     // Jump forward in time

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -138,6 +138,7 @@ pub enum Error {
     AmountBelowMin = 21,
     AmountAboveMax = 22,
     InvalidExpiry = 23,
+    DuplicateIdempotencyKey = 24,
 }
 
 #[contracttype]
@@ -171,6 +172,7 @@ pub enum DataKey {
     AllowedToken(Address),
     MerchantAmountLimits(Address),
     GlobalAmountLimits,
+    IdempotencyKey(String),
 }
 
 const SHORT_LIVE_TTL: u32 = 120_960; // ~1 week at 5s/ledger
@@ -1189,9 +1191,30 @@ impl PaymentProcessor {
         memo: Option<String>,
         memo_type: Option<String>,
         token_address: Option<Address>,
+        /// Optional idempotency key. If provided, retrying with the same key and payment_id
+        /// returns the existing payment. Using the same key with a different payment_id
+        /// returns `DuplicateIdempotencyKey`.
+        client_token: Option<String>,
     ) -> Result<PaymentCharge, Error> {
         Self::require_not_paused(&env)?;
         merchant_id.require_auth();
+
+        // Idempotency check: if client_token was already used, return the existing payment
+        // (or error if it maps to a different payment_id).
+        if let Some(ref token) = client_token {
+            let key = DataKey::IdempotencyKey(token.clone());
+            if let Some(existing_id) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, String>(&key)
+            {
+                if existing_id == payment_id {
+                    return Self::get_payment_internal(&env, &payment_id);
+                } else {
+                    return Err(Error::DuplicateIdempotencyKey);
+                }
+            }
+        }
 
         // Verify that the merchant has the MERCHANT role (granted on verification)
         if !AccessControl::has_role(&env, &role_merchant(&env), &merchant_id) {
@@ -1305,6 +1328,13 @@ impl PaymentProcessor {
             ),
             (merchant_id, amount),
         );
+
+        // Persist idempotency key → payment_id mapping so retries are safe.
+        if let Some(token) = client_token {
+            let key = DataKey::IdempotencyKey(token);
+            env.storage().persistent().set(&key, &payment_id);
+            Self::bump_ttl(&env, &key, LONG_LIVE_TTL);
+        }
 
         Ok(payment)
     }

--- a/fluxapay/src/memo_test.rs
+++ b/fluxapay/src/memo_test.rs
@@ -39,6 +39,7 @@ fn test_create_payment_with_memo() {
         &memo,
             &memo_type,
     &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(payment.payment_id, payment_id);
@@ -70,6 +71,7 @@ fn test_create_payment_without_memo() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(payment.payment_id, payment_id);
@@ -103,6 +105,7 @@ fn test_create_payment_with_id_memo() {
         &memo,
             &memo_type,
     &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(payment.memo, Some(String::from_str(&env, "123456789")));
@@ -135,6 +138,7 @@ fn test_create_payment_with_hash_memo() {
         &memo,
             &memo_type,
     &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(
@@ -170,6 +174,7 @@ fn test_memo_persists_after_verification() {
         &memo,
             &memo_type,
     &None::<Address>,
+    &None::<String>,
     );
 
     // Verify payment

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -347,6 +347,7 @@ fn test_unverified_merchant_cannot_create_payment() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 }
 
@@ -403,6 +404,7 @@ fn test_verified_merchant_can_create_payment() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(payment.payment_id, payment_id);

--- a/fluxapay/src/pause_test.rs
+++ b/fluxapay/src/pause_test.rs
@@ -58,6 +58,7 @@ fn test_create_payment_when_paused() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 }
 
@@ -84,6 +85,7 @@ fn test_verify_payment_when_paused() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     // Pause the contract
@@ -124,6 +126,7 @@ fn test_cancel_payment_when_paused() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     // Pause the contract
@@ -159,6 +162,7 @@ fn test_create_payment_after_unpause() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(payment.status, PaymentStatus::Pending);

--- a/fluxapay/src/proptests.rs
+++ b/fluxapay/src/proptests.rs
@@ -92,6 +92,7 @@ proptest! {
                         &None::<String>,
             &None::<String>,
             &None::<Address>,
+        &None::<String>,
         );
 
         env.ledger().set_timestamp(expires_at + after_expiry);
@@ -138,6 +139,7 @@ proptest! {
                         &None::<String>,
             &None::<String>,
             &None::<Address>,
+        &None::<String>,
         );
 
         let status = client.verify_payment(

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -57,6 +57,7 @@ fn test_create_payment() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(payment.payment_id, payment_id);
@@ -95,6 +96,7 @@ fn test_create_payment_rate_limit_enforced() {
                         &None::<String>,
             &None::<String>,
             &None::<Address>,
+        &None::<String>,
         );
     }
 
@@ -110,6 +112,7 @@ fn test_create_payment_rate_limit_enforced() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(overflow, Err(Ok(Error::RateLimitExceeded)));
@@ -138,6 +141,7 @@ fn test_verify_payment_success() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let payer_address = Address::generate(&env);
@@ -182,6 +186,7 @@ fn test_verify_payment_partially_paid() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let oracle = Address::generate(&env);
@@ -226,6 +231,7 @@ fn test_verify_payment_overpaid() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let oracle = Address::generate(&env);
@@ -270,6 +276,7 @@ fn test_verify_payment_within_tolerance() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let oracle = Address::generate(&env);
@@ -318,6 +325,7 @@ fn test_get_merchant_payments_index_and_pagination() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     client.create_payment(
         &payment_id_2,
@@ -330,6 +338,7 @@ fn test_get_merchant_payments_index_and_pagination() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     client.create_payment(
         &payment_id_3,
@@ -342,6 +351,7 @@ fn test_get_merchant_payments_index_and_pagination() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let all = client.get_merchant_payments(&merchant_id);
@@ -378,6 +388,7 @@ fn test_cancel_pending_success() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     // Set time to before expiry
@@ -412,6 +423,7 @@ fn test_cancel_fails_when_confirmed() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let oracle = Address::generate(&env);
@@ -451,6 +463,7 @@ fn test_expiry_logic() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     // Set time to past expiry
@@ -486,6 +499,7 @@ fn test_unauthorized_cancel() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     let random_addr = Address::generate(&env);
@@ -515,6 +529,7 @@ fn test_expire_payment_after_deadline() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     env.ledger().set_timestamp(expires_at + 1);
@@ -739,6 +754,7 @@ fn test_create_payment_requires_auth() {
                 &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 }
 
@@ -1230,6 +1246,7 @@ fn test_create_payment_with_explicit_expires_at() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(payment.expires_at, expires_at);
 }
@@ -1256,6 +1273,7 @@ fn test_create_payment_with_duration_secs() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(payment.expires_at, now + duration);
 }
@@ -1281,6 +1299,7 @@ fn test_create_payment_defaults_to_one_hour() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(payment.expires_at, now + DEFAULT_PAYMENT_DURATION_SECS);
 }
@@ -1306,6 +1325,7 @@ fn test_create_payment_explicit_expires_at_overrides_duration() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(payment.expires_at, explicit_ts);
 }
@@ -1332,6 +1352,7 @@ fn test_create_payment_past_expires_at_fails() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(result, Err(Ok(Error::InvalidExpiry)));
 }
@@ -1356,6 +1377,7 @@ fn test_create_payment_zero_duration_fails() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(result, Err(Ok(Error::InvalidExpiry)));
 }
@@ -1384,6 +1406,7 @@ fn test_global_min_limit_blocks_payment() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(result, Err(Ok(Error::AmountBelowMin)));
 }
@@ -1410,6 +1433,7 @@ fn test_global_max_limit_blocks_payment() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(result, Err(Ok(Error::AmountAboveMax)));
 }
@@ -1436,6 +1460,7 @@ fn test_global_limits_allow_payment_within_range() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(payment.status, PaymentStatus::Pending);
 }
@@ -1467,6 +1492,7 @@ fn test_merchant_limits_override_global_limits() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(payment.status, PaymentStatus::Pending);
 }
@@ -1493,6 +1519,7 @@ fn test_merchant_max_limit_blocks_payment() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
     assert_eq!(result, Err(Ok(Error::AmountAboveMax)));
 }
@@ -1571,6 +1598,7 @@ fn test_create_payment_with_allowed_token() {
         &None::<String>,
         &None::<String>,
         &Some(alt_token.clone()),
+    &None::<String>,
     );
 
     assert_eq!(payment.token_address, Some(alt_token));
@@ -1603,6 +1631,7 @@ fn test_create_payment_with_unlisted_token_fails() {
         &None::<String>,
         &None::<String>,
         &Some(unknown_token),
+    &None::<String>,
     );
 
     assert_eq!(result, Err(Ok(Error::UnsupportedToken)));
@@ -1628,6 +1657,7 @@ fn test_create_payment_no_token_address_uses_default() {
         &None::<String>,
         &None::<String>,
         &None::<Address>,
+    &None::<String>,
     );
 
     assert_eq!(payment.token_address, None);
@@ -1666,6 +1696,7 @@ fn test_verify_payment_decimal_aware_tolerance_7_decimals() {
         &None::<String>,
         &None::<String>,
         &Some(alt_token),
+    &None::<String>,
     );
 
     // Underpay by 10 (within 7-decimal tolerance of 10) → Confirmed
@@ -1710,6 +1741,7 @@ fn test_verify_payment_decimal_aware_tolerance_7_decimals_overpay() {
         &None::<String>,
         &None::<String>,
         &Some(alt_token),
+    &None::<String>,
     );
 
     // Underpay by 11 → PartiallyPaid
@@ -1836,4 +1868,141 @@ fn test_rejected_refunds_not_counted_in_cumulative_total() {
     let refund = client.get_refund(&new_refund_id);
     assert_eq!(refund.amount, payment_amount);
     assert_eq!(refund.status, RefundStatus::Pending);
+}
+
+// --- Idempotency key (client_token) tests ---
+
+#[test]
+fn test_create_payment_idempotency_retry_returns_same_payment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let payment_id = String::from_str(&env, "idem_pay_1");
+    let client_token = Some(String::from_str(&env, "tok_abc123"));
+    let expires_at = env.ledger().timestamp() + 3600;
+
+    let first = client.create_payment(
+        &payment_id,
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(expires_at),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+        &client_token,
+    );
+
+    // Retry with same client_token and payment_id — must return the same payment
+    let retry = client.create_payment(
+        &payment_id,
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(expires_at),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+        &client_token,
+    );
+
+    assert_eq!(first.payment_id, retry.payment_id);
+    assert_eq!(first.created_at, retry.created_at);
+}
+
+#[test]
+fn test_create_payment_idempotency_different_payment_id_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let client_token = Some(String::from_str(&env, "tok_conflict"));
+    let expires_at = env.ledger().timestamp() + 3600;
+
+    // First call succeeds
+    client.create_payment(
+        &String::from_str(&env, "idem_pay_a"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(expires_at),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+        &client_token,
+    );
+
+    // Second call with same token but different payment_id must fail
+    let result = client.try_create_payment(
+        &String::from_str(&env, "idem_pay_b"),
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(expires_at),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+        &client_token,
+    );
+
+    assert_eq!(result, Err(Ok(Error::DuplicateIdempotencyKey)));
+}
+
+#[test]
+fn test_create_payment_without_client_token_allows_duplicate_id_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let payment_id = String::from_str(&env, "idem_pay_no_tok");
+    let expires_at = env.ledger().timestamp() + 3600;
+
+    client.create_payment(
+        &payment_id,
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(expires_at),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+        &None::<String>,
+    );
+
+    // Without a client_token, a second call with the same payment_id returns PaymentAlreadyExists
+    let result = client.try_create_payment(
+        &payment_id,
+        &merchant_id,
+        &1000i128,
+        &Symbol::new(&env, "USDC"),
+        &Address::generate(&env),
+        &Some(expires_at),
+        &None::<u64>,
+        &None::<String>,
+        &None::<String>,
+        &None::<Address>,
+        &None::<String>,
+    );
+
+    assert_eq!(result, Err(Ok(Error::PaymentAlreadyExists)));
 }


### PR DESCRIPTION
- Add DuplicateIdempotencyKey error (code 24)
- Add IdempotencyKey(String) DataKey variant
- Add client_token: Option<String> param to create_payment
- On retry with same token + payment_id, return existing payment
- On same token with different payment_id, return DuplicateIdempotencyKey
- Store key with LONG_LIVE_TTL after successful creation
- Update all existing call sites with None::<String>
- Add 3 tests covering retry, conflict, and no-token cases

closes #113 