### PR TITLE
 feat: billing intervals, payment metadata hash, dispute auto-escalation, batch stream cancel

### DIFF
--- a/fluxapay/src/integration_test.rs
+++ b/fluxapay/src/integration_test.rs
@@ -78,6 +78,7 @@ fn test_happy_path_flow() {
         memo_type: None,
         token_address: None,
         client_token: None,
+        metadata_hash: None,
     };
     payment_client.create_payment(&args);
 
@@ -147,6 +148,7 @@ fn test_settlement_path() {
         memo_type: None,
         token_address: None,
         client_token: None,
+        metadata_hash: None,
     };
     payment_client.create_payment(&args);
 
@@ -199,6 +201,7 @@ fn test_failure_and_expiration_path() {
         memo_type: None,
         token_address: None,
         client_token: None,
+        metadata_hash: None,
     };
     payment_client.create_payment(&args);
 

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -65,6 +65,8 @@ pub struct PaymentCharge {
     pub memo_type: Option<String>,
     /// Token contract address used for this payment (None defaults to the configured USDC token).
     pub token_address: Option<Address>,
+    /// Optional 32-byte hash merchants can use to tie a payment to an order ID or customer ID.
+    pub metadata_hash: Option<BytesN<32>>,
 }
 
 #[contracttype]
@@ -187,6 +189,7 @@ pub struct CreatePaymentArgs {
     pub memo_type: Option<String>,
     pub token_address: Option<Address>,
     pub client_token: Option<String>,
+    pub metadata_hash: Option<BytesN<32>>,
 }
 
 #[contracttype]
@@ -322,6 +325,27 @@ pub struct Subscription {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BillingInterval {
+    Daily,
+    Weekly,
+    Monthly,
+    Annually,
+}
+
+impl BillingInterval {
+    /// Returns the approximate duration in seconds for each interval.
+    pub fn to_secs(&self) -> u64 {
+        match self {
+            BillingInterval::Daily => 86_400,
+            BillingInterval::Weekly => 604_800,
+            BillingInterval::Monthly => 2_592_000,   // 30 days
+            BillingInterval::Annually => 31_536_000, // 365 days
+        }
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SubscriptionPlan {
     pub plan_id: String,
     pub merchant_id: Address,
@@ -330,6 +354,7 @@ pub struct SubscriptionPlan {
     pub amount: i128,
     pub currency: Symbol,
     pub interval_secs: u64,
+    pub billing_interval: BillingInterval,
     pub active: bool,
 }
 
@@ -490,6 +515,7 @@ impl RefundManager {
                 memo: None,
                 memo_type: None,
                 token_address: None,
+                metadata_hash: None,
             };
             env.storage()
                 .persistent()
@@ -1157,7 +1183,26 @@ impl RefundManager {
     }
 
     pub fn get_dispute(env: Env, dispute_id: String) -> Result<Dispute, Error> {
-        Self::get_dispute_internal(&env, &dispute_id)
+        let mut dispute = Self::get_dispute_internal(&env, &dispute_id)?;
+        let now = env.ledger().timestamp();
+        if let Some(deadline) = dispute.review_deadline {
+            if now > deadline
+                && !dispute.escalated
+                && dispute.status != DisputeStatus::Resolved
+                && dispute.status != DisputeStatus::Rejected
+            {
+                dispute.escalated = true;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Dispute(dispute_id.clone()), &dispute);
+                Self::bump_dispute_ttl(&env, &dispute_id, &dispute.status);
+                env.events().publish(
+                    (Symbol::new(&env, "DISPUTE"), Symbol::new(&env, "ESCALATED")),
+                    (dispute.payment_id.clone(), dispute_id, dispute.amount),
+                );
+            }
+        }
+        Ok(dispute)
     }
 
     pub fn get_payment_disputes(env: Env, payment_id: String) -> Result<Vec<Dispute>, Error> {
@@ -1211,7 +1256,7 @@ impl RefundManager {
         description: String,
         amount: i128,
         currency: Symbol,
-        interval_secs: u64,
+        billing_interval: BillingInterval,
     ) -> Result<(), Error> {
         merchant.require_auth();
 
@@ -1223,9 +1268,7 @@ impl RefundManager {
             return Err(Error::InvalidAmount);
         }
 
-        if interval_secs == 0 {
-            return Err(Error::InvalidAmount);
-        }
+        let interval_secs = billing_interval.to_secs();
 
         let plan = SubscriptionPlan {
             plan_id: plan_id.clone(),
@@ -1235,6 +1278,7 @@ impl RefundManager {
             amount,
             currency,
             interval_secs,
+            billing_interval,
             active: true,
         };
 
@@ -2197,6 +2241,7 @@ impl PaymentProcessor {
             memo: args.memo.clone(),
             memo_type: args.memo_type.clone(),
             token_address: args.token_address.clone(),
+            metadata_hash: args.metadata_hash.clone(),
         };
 
         env.storage()
@@ -2694,6 +2739,7 @@ impl PaymentProcessor {
             memo_type: None,
             token_address: Some(settlement_token),
             client_token: None,
+            metadata_hash: None,
         };
 
         let payment = Self::create_payment(env.clone(), create_args)?;
@@ -2835,6 +2881,14 @@ impl PaymentProcessor {
         stream_ids: Vec<String>,
     ) -> Result<Vec<String>, StreamError> {
         PaymentStreaming::cancel_multiple_streams(env, sender, stream_ids)
+    }
+
+    pub fn batch_cancel_streams(
+        env: Env,
+        sender: Address,
+        stream_ids: Vec<String>,
+    ) -> Result<Vec<String>, StreamError> {
+        PaymentStreaming::batch_cancel_streams(env, sender, stream_ids)
     }
 
     pub fn batch_withdraw_to(

--- a/fluxapay/src/proptests.rs
+++ b/fluxapay/src/proptests.rs
@@ -93,6 +93,7 @@ proptest! {
             memo_type: None,
             token_address: None,
             client_token: None,
+            metadata_hash: None,
         };
 
         client.create_payment(&args);
@@ -142,6 +143,7 @@ proptest! {
             memo_type: None,
             token_address: None,
             client_token: None,
+            metadata_hash: None,
         };
 
         client.create_payment(&args);

--- a/fluxapay/src/stream.rs
+++ b/fluxapay/src/stream.rs
@@ -809,6 +809,77 @@ impl PaymentStreaming {
         Ok(cancelled)
     }
 
+    /// Cancel up to `MAX_BATCH_CANCEL` streams in a single transaction, skipping
+    /// streams that are not active or not owned by `sender` instead of aborting.
+    /// Returns the list of successfully cancelled stream IDs.
+    pub fn batch_cancel_streams(
+        env: Env,
+        sender: Address,
+        stream_ids: Vec<String>,
+    ) -> Result<Vec<String>, StreamError> {
+        const MAX_BATCH_CANCEL: u32 = 20;
+        sender.require_auth();
+
+        let mut cancelled = Vec::new(&env);
+        let now = env.ledger().timestamp();
+
+        for (i, stream_id) in stream_ids.iter().enumerate() {
+            if i as u32 >= MAX_BATCH_CANCEL {
+                break;
+            }
+            let mut stream: PaymentStream = match env
+                .storage()
+                .persistent()
+                .get(&StreamDataKey::Stream(stream_id.clone()))
+            {
+                Some(s) => s,
+                None => continue,
+            };
+
+            if stream.sender != sender || stream.status != StreamStatus::Active {
+                continue;
+            }
+
+            let elapsed = now.saturating_sub(stream.last_checkpoint_at);
+            let newly_accrued = (elapsed as i128)
+                .saturating_mul(stream.rate_per_second)
+                .min(stream.remaining_deposit - stream.accrued_at_checkpoint);
+            stream.accrued_at_checkpoint =
+                stream.accrued_at_checkpoint.saturating_add(newly_accrued);
+            stream.last_checkpoint_at = now;
+
+            let accrued = stream.accrued_at_checkpoint;
+            let refund = stream.remaining_deposit.saturating_sub(accrued);
+
+            stream.status = StreamStatus::Cancelled;
+            stream.remaining_deposit = accrued;
+            env.storage()
+                .persistent()
+                .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
+
+            let token_client = token::Client::new(&env, &stream.token);
+            if accrued > 0 {
+                token_client.transfer(&env.current_contract_address(), &stream.receiver, &accrued);
+            }
+            if refund > 0 {
+                token_client.transfer(&env.current_contract_address(), &stream.sender, &refund);
+            }
+
+            env.events().publish(
+                (
+                    Symbol::new(&env, "STREAM"),
+                    Symbol::new(&env, "CANCELLED"),
+                    stream_id.clone(),
+                ),
+                (sender.clone(), accrued, refund),
+            );
+
+            cancelled.push_back(stream_id);
+        }
+
+        Ok(cancelled)
+    }
+
     // ─── Batch withdrawal ─────────────────────────────────────────────────────
 
     /// Withdraw accrued amounts from multiple streams to specified destinations

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -70,6 +70,7 @@ fn create_payment_args(
         memo_type: None,
         token_address: None,
         client_token: None,
+        metadata_hash: None,
     }
 }
 
@@ -1882,6 +1883,7 @@ fn test_create_payment_idempotency_retry_returns_same_payment() {
         memo_type: None,
         token_address: None,
         client_token: client_token.clone(),
+        metadata_hash: None,
     };
 
     let first = client.create_payment(&args);
@@ -1917,6 +1919,7 @@ fn test_create_payment_idempotency_different_payment_id_fails() {
         memo_type: None,
         token_address: None,
         client_token: client_token.clone(),
+        metadata_hash: None,
     };
 
     // First call succeeds
@@ -1955,6 +1958,7 @@ fn test_create_payment_without_idempotency_token_fails_on_retry() {
         memo_type: None,
         token_address: None,
         client_token: None,
+        metadata_hash: None,
     };
 
     client.create_payment(&args);


### PR DESCRIPTION


PR Description:
  

closes #163
closes #181 
closes #189 
closes #206

  ## Summary
  
  Implements four open issues for the FluxaPay Soroban contract.
  
  ---
  
  ### [#43] Flexible Billing Intervals
  
  Added a `BillingInterval` enum (`Daily`, `Weekly`, `Monthly`, `Annually`) as a `#[contracttype]` with a `to_secs()` helper that maps each variant to its
  canonical second duration. `SubscriptionPlan` now stores a `billing_interval` field alongside the derived `interval_secs`. `create_subscription_plan`
  accepts a `BillingInterval` instead of a raw `u64`, removing the need for callers to manage raw second values.
  
  ---
  
  ### [#17] Custom Payment Metadata Mapping
  
  Added an `Option<BytesN<32>> metadata_hash` field to `PaymentCharge` and `CreatePaymentArgs`. Merchants can supply a 32-byte hash (e.g. SHA-256 of an
  order ID or customer ID) at payment creation time; it is stored on-chain without requiring large strings. All existing `PaymentCharge` construction
  sites and test helpers updated with `metadata_hash: None`.
  
  ---
  
  ### [#35] Auto-Escalation for Expired Disputes
  
  `get_dispute` now checks whether the dispute has a `review_deadline` that has passed. If the dispute is unresolved and not yet escalated, it sets
  `escalated = true`, persists the change, bumps TTL, and emits a `DISPUTE/ESCALATED` event — matching the same logic already used in
  `set_dispute_deadline`. No new storage keys or roles required.
  
  ---
  
  ### [#60] Optimised Batch Stream Cancellation
  
  Added `batch_cancel_streams` to `PaymentStreaming` in `stream.rs` and exposed it on the contract in `lib.rs`. Key differences from
  `cancel_multiple_streams`:
  - Caps processing at **20 streams per call** (`MAX_BATCH_CANCEL`) to stay within Soroban CPU limits.
  - **Skips** streams that are not found, not active, or not owned by the sender instead of aborting the whole batch, so a single bad stream ID doesn't
  roll back valid cancellations.
  - Follows the same CEI pattern (checkpoint → effects → interactions → event) as the existing single-cancel path.
  
  ---
  
  ### Files Changed
  - `fluxapay/src/lib.rs` — all struct and function changes
  - `fluxapay/src/stream.rs` — `batch_cancel_streams` implementation
  - `fluxapay/src/test.rs`, `integration_test.rs`, `proptests.rs` — `metadata_hash: None` added to all `CreatePaymentArgs` literals
