### PR TITLE
Implements four features for FluxaPay's streaming and subscription infrastructure.

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -1729,6 +1729,59 @@ impl RefundManager {
         Ok(())
     }
 
+    /// Submit usage metrics for a metered subscription.
+    ///
+    /// Operators call this to record usage units consumed since the last
+    /// billing cycle. The subscription amount is scaled by
+    /// `units_used * unit_price` and charged immediately via `charge_subscription`.
+    ///
+    /// # Parameters
+    /// * `operator`         – Must hold oracle or settlement_operator role.
+    /// * `subscription_id`  – Target subscription.
+    /// * `units_used`       – Number of usage units consumed this period.
+    /// * `unit_price`       – Price per unit in the subscription token's smallest unit.
+    /// * `token`            – Token contract address used for the charge.
+    pub fn submit_usage_metrics(
+        env: Env,
+        operator: Address,
+        subscription_id: String,
+        units_used: i128,
+        unit_price: i128,
+        token: Address,
+    ) -> Result<SubscriptionStatus, Error> {
+        operator.require_auth();
+
+        if !AccessControl::has_role(&env, &role_oracle(&env), &operator)
+            && !AccessControl::has_role(&env, &role_settlement_operator(&env), &operator)
+        {
+            return Err(Error::Unauthorized);
+        }
+
+        if units_used <= 0 || unit_price <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let mut subscription = Self::get_subscription_internal(&env, &subscription_id)?;
+
+        // Override the subscription amount with the metered charge for this cycle.
+        let metered_amount = units_used.saturating_mul(unit_price);
+        subscription.amount = metered_amount;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(subscription_id.clone()), &subscription);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "SUBSCRIPTION"),
+                Symbol::new(&env, "USAGE_RECORDED"),
+            ),
+            (subscription_id.clone(), units_used, unit_price, metered_amount),
+        );
+
+        // Trigger the charge at the updated metered amount.
+        Self::charge_subscription(env, operator, subscription_id, token)
+    }
+
     /// Process due subscriptions - called by an operator or oracle
     pub fn process_due_subscriptions(env: Env, operator: Address) -> Result<u32, Error> {
         operator.require_auth();
@@ -2977,6 +3030,21 @@ impl PaymentProcessor {
         top_ups: Vec<(String, i128)>,
     ) -> Result<(), StreamError> {
         PaymentStreaming::top_up_multiple_streams(env, sender, top_ups)
+    }
+
+    /// Update the flow rate of an active stream (increase or decrease).
+    pub fn update_stream_rate(
+        env: Env,
+        sender: Address,
+        stream_id: String,
+        new_rate: i128,
+    ) -> Result<(), StreamError> {
+        PaymentStreaming::update_stream_rate(env, sender, stream_id, new_rate)
+    }
+
+    /// Close a terminal (Exhausted/Cancelled) stream and remove its storage entry.
+    pub fn close_expired_stream(env: Env, stream_id: String) -> Result<(), StreamError> {
+        PaymentStreaming::close_expired_stream(env, stream_id)
     }
 }
 

--- a/fluxapay/src/stream.rs
+++ b/fluxapay/src/stream.rs
@@ -860,6 +860,149 @@ impl PaymentStreaming {
         Ok(cancelled)
     }
 
+    // ─── Dynamic rate adjustment ──────────────────────────────────────────────
+
+    /// Update the flow rate of an active stream (increase or decrease).
+    ///
+    /// Unlike `decrease_rate_per_second`, this function allows both increases
+    /// and decreases. Accrued tokens are check-pointed at the current rate
+    /// before the new rate takes effect.
+    ///
+    /// When the rate is **decreased**, any surplus deposit is refunded to the
+    /// sender (same logic as `decrease_rate_per_second`).
+    /// When the rate is **increased**, no additional deposit is required; the
+    /// existing deposit simply drains faster.
+    ///
+    /// # Parameters
+    /// * `sender`    – Must be the original stream sender; must sign.
+    /// * `stream_id` – Stream to update.
+    /// * `new_rate`  – New flow rate (must be > 0).
+    pub fn update_stream_rate(
+        env: Env,
+        sender: Address,
+        stream_id: String,
+        new_rate: i128,
+    ) -> Result<(), StreamError> {
+        sender.require_auth();
+        require_not_paused(&env)?;
+
+        let mut stream: PaymentStream = env
+            .storage()
+            .persistent()
+            .get(&StreamDataKey::Stream(stream_id.clone()))
+            .ok_or(StreamError::StreamNotFound)?;
+
+        if stream.sender != sender {
+            return Err(StreamError::Unauthorized);
+        }
+        if stream.status != StreamStatus::Active {
+            return Err(StreamError::StreamNotActive);
+        }
+        if new_rate <= 0 {
+            return Err(StreamError::InvalidRate);
+        }
+
+        let now = env.ledger().timestamp();
+        let old_rate = stream.rate_per_second;
+
+        // Checkpoint accrued amount at the old rate.
+        let elapsed = now.saturating_sub(stream.last_checkpoint_at);
+        let newly_accrued = (elapsed as i128)
+            .saturating_mul(old_rate)
+            .min(stream.remaining_deposit - stream.accrued_at_checkpoint);
+        stream.accrued_at_checkpoint = stream.accrued_at_checkpoint.saturating_add(newly_accrued);
+        stream.last_checkpoint_at = now;
+
+        // When decreasing: refund surplus deposit no longer needed at the new rate.
+        let surplus = if new_rate < old_rate {
+            let remaining_unlocked = stream
+                .remaining_deposit
+                .saturating_sub(stream.accrued_at_checkpoint);
+            if remaining_unlocked > 0 && old_rate > 0 {
+                let old_seconds_left = remaining_unlocked / old_rate;
+                let new_needed = old_seconds_left.saturating_mul(new_rate);
+                remaining_unlocked.saturating_sub(new_needed).max(0)
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+
+        stream.rate_per_second = new_rate;
+        stream.remaining_deposit = stream.remaining_deposit.saturating_sub(surplus);
+
+        // Persist before interaction (CEI pattern).
+        env.storage()
+            .persistent()
+            .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
+
+        if surplus > 0 {
+            let token_client = token::Client::new(&env, &stream.token);
+            token_client.transfer(&env.current_contract_address(), &stream.sender, &surplus);
+        }
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "STREAM"),
+                Symbol::new(&env, "RATE_UPDATED"),
+                stream_id,
+            ),
+            (sender, old_rate, new_rate, surplus),
+        );
+
+        Ok(())
+    }
+
+    // ─── Expired stream cleanup ───────────────────────────────────────────────
+
+    /// Close an exhausted or cancelled stream and remove its storage entry.
+    ///
+    /// This releases the contract storage slot for streams that have already
+    /// reached a terminal state (`Exhausted` or `Cancelled`). Any remaining
+    /// accrued balance is paid out to the receiver before the key is removed.
+    ///
+    /// Can be called by anyone (permissionless) once the stream is terminal,
+    /// incentivising keepers to clean up storage.
+    ///
+    /// # Parameters
+    /// * `stream_id` – Stream to close and remove.
+    pub fn close_expired_stream(env: Env, stream_id: String) -> Result<(), StreamError> {
+        let stream: PaymentStream = env
+            .storage()
+            .persistent()
+            .get(&StreamDataKey::Stream(stream_id.clone()))
+            .ok_or(StreamError::StreamNotFound)?;
+
+        // Only terminal streams may be cleaned up.
+        if stream.status == StreamStatus::Active {
+            return Err(StreamError::StreamNotActive);
+        }
+
+        // Pay out any residual accrued balance to the receiver.
+        let residual = stream.accrued_at_checkpoint.min(stream.remaining_deposit).max(0);
+        if residual > 0 {
+            let token_client = token::Client::new(&env, &stream.token);
+            token_client.transfer(&env.current_contract_address(), &stream.receiver, &residual);
+        }
+
+        // Remove the storage entry to reclaim ledger space.
+        env.storage()
+            .persistent()
+            .remove(&StreamDataKey::Stream(stream_id.clone()));
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "STREAM"),
+                Symbol::new(&env, "CLOSED"),
+                stream_id,
+            ),
+            (stream.sender, stream.receiver, residual),
+        );
+
+        Ok(())
+    }
+
     // ─── Batch withdrawal ─────────────────────────────────────────────────────
 
     /// Withdraw accrued amounts from multiple streams to specified destinations

--- a/scripts/subscription-daemon.js
+++ b/scripts/subscription-daemon.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * FluxaPay Subscription Indexer Daemon
+ *
+ * Polls the chain for due subscriptions and calls process_due_subscriptions
+ * on the RefundManager contract. Designed to run as a cron job or long-running
+ * process.
+ *
+ * Usage:
+ *   node scripts/subscription-daemon.js
+ *
+ * Environment variables (see .env.example):
+ *   STELLAR_RPC_URL        – Soroban RPC endpoint
+ *   CONTRACT_ID            – RefundManager contract address
+ *   OPERATOR_SECRET        – Operator secret key (settlement_operator role)
+ *   POLL_INTERVAL_MS       – How often to poll in ms (default: 60000)
+ *   NETWORK_PASSPHRASE     – Stellar network passphrase
+ */
+
+"use strict";
+
+const {
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  Keypair,
+  Contract,
+  nativeToScVal,
+  BASE_FEE,
+  xdr,
+} = require("@stellar/stellar-sdk");
+
+const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+const CONTRACT_ID = process.env.CONTRACT_ID;
+const OPERATOR_SECRET = process.env.OPERATOR_SECRET;
+const POLL_INTERVAL_MS = parseInt(process.env.POLL_INTERVAL_MS || "60000", 10);
+const NETWORK_PASSPHRASE = process.env.NETWORK_PASSPHRASE || Networks.TESTNET;
+
+if (!CONTRACT_ID || !OPERATOR_SECRET) {
+  console.error("ERROR: CONTRACT_ID and OPERATOR_SECRET must be set.");
+  process.exit(1);
+}
+
+const server = new SorobanRpc.Server(RPC_URL, { allowHttp: RPC_URL.startsWith("http://") });
+const operatorKeypair = Keypair.fromSecret(OPERATOR_SECRET);
+const contract = new Contract(CONTRACT_ID);
+
+/**
+ * Fetch all active subscription IDs from contract storage by scanning
+ * the SubscriptionCounter and individual Subscription entries.
+ *
+ * In production this would be replaced by a Mercury/Horizon event query
+ * that tracks SUBSCRIPTION/CREATED events to build the index off-chain.
+ */
+async function fetchDueSubscriptionIds() {
+  // Query the SubscriptionCounter to know the range of IDs to check.
+  const counterKey = xdr.LedgerKey.contractData(
+    new xdr.LedgerKeyContractData({
+      contract: contract.address().toScAddress(),
+      key: xdr.ScVal.scvLedgerKeyContractInstance(),
+      durability: xdr.ContractDataDurability.persistent(),
+    })
+  );
+
+  // Fetch ledger entries for subscriptions via RPC getLedgerEntries.
+  // The daemon relies on an off-chain index (e.g. PostgreSQL populated by
+  // the Mercury indexer sync.yml) to enumerate subscription IDs efficiently.
+  // Here we read from a local JSON file written by the indexer as a fallback.
+  const fs = require("fs");
+  const indexPath = process.env.SUBSCRIPTION_INDEX_PATH || "/tmp/fluxapay_subscriptions.json";
+
+  if (!fs.existsSync(indexPath)) {
+    console.warn(`[daemon] No subscription index found at ${indexPath}. Skipping cycle.`);
+    return [];
+  }
+
+  const index = JSON.parse(fs.readFileSync(indexPath, "utf8"));
+  const nowSecs = Math.floor(Date.now() / 1000);
+
+  // Filter to subscriptions that are Active and past their next_payment_at.
+  return (index.subscriptions || [])
+    .filter(
+      (s) =>
+        s.status === "Active" &&
+        (s.next_payment_at <= nowSecs || (s.next_retry_at && s.next_retry_at <= nowSecs))
+    )
+    .map((s) => s.subscription_id);
+}
+
+/**
+ * Call process_due_subscriptions on the contract.
+ * Returns the number of subscriptions processed.
+ */
+async function triggerProcessDue() {
+  const account = await server.getAccount(operatorKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call(
+        "process_due_subscriptions",
+        nativeToScVal(operatorKeypair.publicKey(), { type: "address" })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const preparedTx = await server.prepareTransaction(tx);
+  preparedTx.sign(operatorKeypair);
+
+  const sendResult = await server.sendTransaction(preparedTx);
+  if (sendResult.status === "ERROR") {
+    throw new Error(`Transaction failed: ${JSON.stringify(sendResult.errorResult)}`);
+  }
+
+  // Poll for confirmation.
+  let getResult;
+  for (let i = 0; i < 10; i++) {
+    await sleep(3000);
+    getResult = await server.getTransaction(sendResult.hash);
+    if (getResult.status !== "NOT_FOUND") break;
+  }
+
+  if (getResult.status === "SUCCESS") {
+    const processed = getResult.returnValue
+      ? parseInt(getResult.returnValue.value(), 10)
+      : 0;
+    return processed;
+  }
+
+  throw new Error(`Transaction did not succeed: ${getResult.status}`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runCycle() {
+  console.log(`[daemon] ${new Date().toISOString()} – starting cycle`);
+  try {
+    const dueIds = await fetchDueSubscriptionIds();
+    if (dueIds.length === 0) {
+      console.log("[daemon] No due subscriptions found.");
+      return;
+    }
+    console.log(`[daemon] Found ${dueIds.length} due subscription(s). Triggering contract call…`);
+    const processed = await triggerProcessDue();
+    console.log(`[daemon] process_due_subscriptions returned: ${processed} processed.`);
+  } catch (err) {
+    console.error("[daemon] Cycle error:", err.message || err);
+  }
+}
+
+async function main() {
+  console.log(`[daemon] Starting FluxaPay subscription daemon (poll every ${POLL_INTERVAL_MS}ms)`);
+  console.log(`[daemon] Contract: ${CONTRACT_ID}`);
+  console.log(`[daemon] Operator: ${operatorKeypair.publicKey()}`);
+
+  // Run immediately, then on interval.
+  await runCycle();
+  setInterval(runCycle, POLL_INTERVAL_MS);
+}
+
+main().catch((err) => {
+  console.error("[daemon] Fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
closes #187 
closes #195 
closes #197
closes #204

 PR Description
  
  Summary
  
  Implements four features for FluxaPay's streaming and subscription infrastructure.
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 41 — Off-Chain Subscription Indexer Daemon
  
  File: scripts/subscription-daemon.js
  
  A Node.js daemon that polls for due subscriptions and calls process_due_subscriptions on the
  contract. It:
  
  - Reads an off-chain subscription index (populated by the Mercury indexer) to find subscriptions
  where next_payment_at or next_retry_at ≤ now
  - Builds and submits a signed Soroban transaction as the operator
  - Runs on a configurable interval (default 60s) via setInterval, suitable for cron or a
  long-running process
  - Configured entirely via environment variables (CONTRACT_ID, OPERATOR_SECRET, STELLAR_RPC_URL,
  etc.)
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 49 — Metered Subscription Billing
  
  File: fluxapay/src/lib.rs — RefundManager::submit_usage_metrics
  
  Operators (oracle or settlement_operator role) submit periodic usage data on-chain:
  
  - Takes units_used × unit_price to compute the metered charge for the cycle
  - Overwrites subscription.amount with the computed value, then delegates to charge_subscription
   to execute the token transfer
  - Emits a SUBSCRIPTION/USAGE_RECORDED event with units, price, and total
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 51 — Dynamic Flow Rate Adjustment
  
  File: fluxapay/src/stream.rs — PaymentStreaming::update_stream_rate
  File: fluxapay/src/lib.rs — PaymentProcessor::update_stream_rate (passthrough)
  
  Allows streams to be updated without cancelling and recreating:
  
  - Checkpoints accrued tokens at the old rate before switching
  - On decrease: refunds surplus deposit to sender (same math as decrease_rate_per_second)
  - On increase: no refund needed; deposit drains faster
  - Emits STREAM/RATE_UPDATED event with old rate, new rate, and any surplus refunded
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 58 — Automatic Closure of Expired Streams
  
  File: fluxapay/src/stream.rs — PaymentStreaming::close_expired_stream
  File: fluxapay/src/lib.rs — PaymentProcessor::close_expired_stream (passthrough)
  
  Permissionless cleanup of terminal streams (Exhausted or Cancelled):
  
  - Pays out any residual accrued_at_checkpoint balance to the receiver
  - Calls env.storage().persistent().remove(...) to free the storage slot
  - Emits STREAM/CLOSED event
  - Callable by anyone (keeper-friendly), active streams are rejected
