### PR TITLE
feat(stream): emit remaining_deposit in STREAM/WITHDRAWN events

### DIFF
--- a/fluxapay/EVENTS.md
+++ b/fluxapay/EVENTS.md
@@ -174,3 +174,8 @@ Emitted by the `PaymentProcessor` contract.
 Emitted when a new payment stream is created.
 - **Topics**: `(STREAM, CREATED)`
 - **Data**: `(stream_id: String, sender: Address, amount: i128)`
+
+### STREAM/WITHDRAWN
+Emitted when accrued tokens are withdrawn from a stream.
+- **Topics**: `(STREAM, WITHDRAWN, stream_id)`
+- **Data**: `(receiver: Address, destination: Address, amount: i128, remaining_deposit: i128)`

--- a/fluxapay/src/stream.rs
+++ b/fluxapay/src/stream.rs
@@ -608,7 +608,7 @@ impl PaymentStreaming {
                         Symbol::new(&env, "WITHDRAWN"),
                         stream_id.clone(),
                     ),
-                    (recipient.clone(), recipient.clone(), withdrawable),
+                    (recipient.clone(), recipient.clone(), withdrawable, stream.remaining_deposit),
                 );
 
                 processed.push_back(stream_id);
@@ -689,7 +689,7 @@ impl PaymentStreaming {
                 Symbol::new(&env, "WITHDRAWN"),
                 stream_id.clone(),
             ),
-            (stream.receiver.clone(), destination.clone(), withdrawable),
+            (stream.receiver.clone(), destination.clone(), withdrawable, stream.remaining_deposit),
         );
 
         Ok(stream_id)
@@ -1035,6 +1035,8 @@ impl PaymentStreaming {
         );
 
         Ok(())
+    }
+
     /// Cancel up to `MAX_BATCH_CANCEL` streams in a single transaction, skipping
     /// streams that are not active or not owned by `sender` instead of aborting.
     /// Returns the list of successfully cancelled stream IDs.
@@ -1186,7 +1188,7 @@ impl PaymentStreaming {
                     Symbol::new(&env, "WITHDRAWN"),
                     w.stream_id.clone(),
                 ),
-                (recipient.clone(), w.destination.clone(), withdrawable),
+                (recipient.clone(), w.destination.clone(), withdrawable, stream.remaining_deposit),
             );
 
             processed.push_back(w.stream_id.clone());

--- a/fluxapay/src/stream_test.rs
+++ b/fluxapay/src/stream_test.rs
@@ -299,3 +299,25 @@ fn test_get_sender_streams_pagination() {
     let page3 = client.get_sender_streams(&sender, &2u32, &2u32);
     assert_eq!(page3.len(), 1);
 }
+
+#[test]
+fn test_withdrawn_event_includes_remaining_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, sender, receiver, token) = setup(&env);
+    let token_client = token::StellarAssetClient::new(&env, &token);
+
+    let stream_id = String::from_str(&env, "stream_event");
+    let destination = Address::generate(&env);
+
+    // rate=10, deposit=500 → after 10s: withdrawable=100, remaining=400
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id);
+    client.set_stream_destination(&receiver, &stream_id, &destination);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 10);
+    client.trigger_withdrawal(&stream_id);
+
+    let stream = client.get_stream(&stream_id);
+    assert_eq!(stream.remaining_deposit, 400);
+    assert_eq!(token_client.balance(&destination), 100i128);
+}


### PR DESCRIPTION
closes #201 

Add remaining contract balance to the STREAM/WITHDRAWN event payload for all three withdrawal paths (withdraw_all_for_recipient, trigger_withdrawal, batch_withdraw_to), enabling indexers to track accrued vs withdrawn amounts without a secondary storage lookup.

Also fix pre-existing missing closing brace on close_expired_stream that caused a compile error.