### PR TITLE
feat(#63): tier-based monthly transaction volume caps

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -19,6 +19,13 @@ const REFUND_FEE_BPS_BASIC: i128 = 100;     // 1.0% for Basic tier
 const REFUND_FEE_BPS_FULL: i128 = 80;       // 0.8% for Full tier
 const REFUND_FEE_BPS_BUSINESS: i128 = 50;   // 0.5% for Business tier
 
+// Issue #63: Monthly processing volume caps per KYC tier (in USDC stroops, 7 decimals)
+// Unverified: $500, Basic: $10,000, Full: $100,000, Business: unlimited (i128::MAX)
+const TIER_CAP_UNVERIFIED: i128 = 5_000_000_000;       // $500
+const TIER_CAP_BASIC: i128 = 100_000_000_000;           // $10,000
+const TIER_CAP_FULL: i128 = 1_000_000_000_000;          // $100,000
+const TIER_CAP_BUSINESS: i128 = i128::MAX;              // unlimited
+
 /// Maximum number of payment retries before a subscription is cancelled.
 pub const SUBSCRIPTION_MAX_RETRIES: u32 = 3;
 /// Spacing between retry attempts in seconds (2 days).
@@ -178,6 +185,8 @@ pub enum Error {
     InvalidResumeTimestamp = 32,
     /// Merchant authorization error (see MerchantAuthError for details).
     MerchantAuthError = 33,
+    /// Merchant has exceeded their KYC tier monthly processing volume cap.
+    TierVolumeLimitExceeded = 34,
 }
 
 #[contracttype]
@@ -435,6 +444,8 @@ pub enum DataKey {
     DisputeVote(String, Address),
     /// Tally of votes for a dispute
     DisputeVoteTally(String),
+    /// Monthly volume tracker: (merchant_id, month_epoch) → i128 cumulative amount
+    MerchantMonthlyVolume(Address, u32),
 }
 
 // When building for WASM deployment, only the active contract's #[contractimpl]
@@ -3076,6 +3087,11 @@ impl PaymentProcessor {
             PaymentStatus::PartiallyPaid
         };
 
+        // Issue #63: Enforce tier-based monthly volume cap before confirming payment.
+        if new_status == PaymentStatus::Confirmed || new_status == PaymentStatus::Overpaid {
+            Self::enforce_tier_volume_cap(&env, &payment.merchant_id, amount_received)?;
+        }
+
         payment.status = new_status.clone();
 
         env.storage()
@@ -3502,6 +3518,59 @@ impl PaymentProcessor {
             .persistent()
             .set(&DataKey::StreamCounter, &counter);
         counter
+    }
+
+    /// Enforce KYC tier monthly volume cap. Returns `TierVolumeLimitExceeded` if adding
+    /// `amount` would exceed the merchant's tier cap for the current calendar month.
+    /// On success, persists the updated cumulative volume.
+    fn enforce_tier_volume_cap(
+        env: &Env,
+        merchant_id: &Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        // Derive the monthly cap from the merchant's KYC tier (cross-contract if registry set).
+        let cap = if let Some(registry_address) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::MerchantRegistryAddress)
+        {
+            let registry_client =
+                crate::merchant_registry::MerchantRegistryClient::new(env, &registry_address);
+            match registry_client.try_get_merchant(merchant_id) {
+                Ok(Ok(merchant)) => {
+                    use crate::merchant_registry::KycTier;
+                    match merchant.kyc_tier {
+                        KycTier::Business => TIER_CAP_BUSINESS,
+                        KycTier::Full => TIER_CAP_FULL,
+                        KycTier::Basic => TIER_CAP_BASIC,
+                        KycTier::Unverified => TIER_CAP_UNVERIFIED,
+                    }
+                }
+                _ => TIER_CAP_UNVERIFIED,
+            }
+        } else {
+            TIER_CAP_BUSINESS // No registry → no cap
+        };
+
+        if cap == i128::MAX {
+            return Ok(()); // Business tier: unlimited
+        }
+
+        // Month epoch: seconds since Unix epoch / seconds-per-30-days, cast to u32.
+        let month_epoch = (env.ledger().timestamp() / 2_592_000) as u32;
+        let key = DataKey::MerchantMonthlyVolume(merchant_id.clone(), month_epoch);
+
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        let new_total = current.saturating_add(amount);
+
+        if new_total > cap {
+            return Err(Error::TierVolumeLimitExceeded);
+        }
+
+        env.storage().persistent().set(&key, &new_total);
+        Self::bump_ttl(env, &key, LONG_LIVE_TTL);
+
+        Ok(())
     }
 
     fn get_payment_internal(env: &Env, payment_id: &String) -> Result<PaymentCharge, Error> {

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -1221,3 +1221,215 @@ fn test_set_kyc_tier_with_oracle_signature() {
     let merchant = client.get_merchant(&merchant_id);
     assert_eq!(merchant.oracle_signature, Some(signature));
 }
+
+// ─── Tier-Based Volume Cap Tests (Issue #63) ─────────────────────────────────
+
+fn setup_volume_cap_env(
+    env: &Env,
+) -> (
+    Address,
+    PaymentProcessorClient<'_>,
+    MerchantRegistryClient<'_>,
+    Address, // merchant
+    Address, // oracle
+) {
+    let payment_contract = env.register(crate::PaymentProcessor, ());
+    let registry_contract = env.register(MerchantRegistry, ());
+
+    let payment_client = PaymentProcessorClient::new(env, &payment_contract);
+    let registry_client = MerchantRegistryClient::new(env, &registry_contract);
+
+    let admin = Address::generate(env);
+    payment_client.initialize_payment_processor(&admin);
+    registry_client.initialize(&admin);
+
+    // Link registry to payment processor
+    payment_client.set_merchant_registry_address(&admin, &registry_contract);
+
+    let merchant = Address::generate(env);
+    let oracle = Address::generate(env);
+
+    payment_client.grant_role(&admin, &Symbol::new(env, "MERCHANT"), &merchant);
+    payment_client.grant_role(&admin, &Symbol::new(env, "ORACLE"), &oracle);
+
+    registry_client.register_merchant(
+        &merchant,
+        &String::from_str(env, "Test Merchant"),
+        &String::from_str(env, "USDC"),
+        &None::<Address>,
+        &None::<String>,
+        &None,
+    );
+
+    (admin, payment_client, registry_client, merchant, oracle)
+}
+
+#[test]
+fn test_basic_tier_cap_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+
+    let (admin, payment_client, registry_client, merchant, oracle) =
+        setup_volume_cap_env(&env);
+
+    // Set merchant to Basic tier ($10,000 cap = 100_000_000_000 stroops)
+    registry_client.set_kyc_tier(&admin, &merchant, &KycTier::Basic, &String::from_str(&env, "sig"));
+
+    let deposit = Address::generate(&env);
+
+    // First payment: $9,000 — should succeed
+    let pid1 = String::from_str(&env, "pay_1");
+    payment_client.create_payment(&crate::CreatePaymentArgs {
+        payment_id: pid1.clone(),
+        merchant_id: merchant.clone(),
+        amount: 90_000_000_000,
+        currency: Symbol::new(&env, "USDC"),
+        deposit_address: deposit.clone(),
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+    });
+    payment_client.verify_payment(
+        &oracle,
+        &pid1,
+        &soroban_sdk::BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &90_000_000_000,
+    );
+
+    // Second payment: $2,000 — would push total to $11,000, exceeding $10,000 cap
+    let pid2 = String::from_str(&env, "pay_2");
+    payment_client.create_payment(&crate::CreatePaymentArgs {
+        payment_id: pid2.clone(),
+        merchant_id: merchant.clone(),
+        amount: 20_000_000_000,
+        currency: Symbol::new(&env, "USDC"),
+        deposit_address: deposit.clone(),
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+    });
+
+    let result = payment_client.try_verify_payment(
+        &oracle,
+        &pid2,
+        &soroban_sdk::BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &20_000_000_000,
+    );
+    assert!(result.is_err(), "Expected TierVolumeLimitExceeded error");
+}
+
+#[test]
+fn test_business_tier_no_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+
+    let (admin, payment_client, registry_client, merchant, oracle) =
+        setup_volume_cap_env(&env);
+
+    // Business tier: unlimited
+    registry_client.set_kyc_tier(&admin, &merchant, &KycTier::Business, &String::from_str(&env, "sig"));
+
+    let deposit = Address::generate(&env);
+
+    // Pay well above any cap — should succeed
+    let pid = String::from_str(&env, "pay_big");
+    payment_client.create_payment(&crate::CreatePaymentArgs {
+        payment_id: pid.clone(),
+        merchant_id: merchant.clone(),
+        amount: 10_000_000_000_000, // $1,000,000
+        currency: Symbol::new(&env, "USDC"),
+        deposit_address: deposit.clone(),
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+    });
+    payment_client.verify_payment(
+        &oracle,
+        &pid,
+        &soroban_sdk::BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &10_000_000_000_000,
+    );
+}
+
+#[test]
+fn test_volume_resets_next_month() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Start at beginning of a month epoch
+    env.ledger().with_mut(|li| li.timestamp = 2_592_000); // epoch 1
+
+    let (admin, payment_client, registry_client, merchant, oracle) =
+        setup_volume_cap_env(&env);
+
+    registry_client.set_kyc_tier(&admin, &merchant, &KycTier::Basic, &String::from_str(&env, "sig"));
+
+    let deposit = Address::generate(&env);
+
+    // Fill up the cap this month ($10,000)
+    let pid1 = String::from_str(&env, "pay_m1");
+    payment_client.create_payment(&crate::CreatePaymentArgs {
+        payment_id: pid1.clone(),
+        merchant_id: merchant.clone(),
+        amount: 100_000_000_000,
+        currency: Symbol::new(&env, "USDC"),
+        deposit_address: deposit.clone(),
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+    });
+    payment_client.verify_payment(
+        &oracle,
+        &pid1,
+        &soroban_sdk::BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &100_000_000_000,
+    );
+
+    // Advance to next month epoch
+    env.ledger().with_mut(|li| li.timestamp = 2 * 2_592_000 + 1); // epoch 2
+
+    // Same amount should succeed in the new month
+    let pid2 = String::from_str(&env, "pay_m2");
+    payment_client.create_payment(&crate::CreatePaymentArgs {
+        payment_id: pid2.clone(),
+        merchant_id: merchant.clone(),
+        amount: 100_000_000_000,
+        currency: Symbol::new(&env, "USDC"),
+        deposit_address: deposit.clone(),
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+    });
+    payment_client.verify_payment(
+        &oracle,
+        &pid2,
+        &soroban_sdk::BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &100_000_000_000,
+    );
+}

--- a/fluxapay/src/stream.rs
+++ b/fluxapay/src/stream.rs
@@ -1035,6 +1035,8 @@ impl PaymentStreaming {
         );
 
         Ok(())
+    }
+
     /// Cancel up to `MAX_BATCH_CANCEL` streams in a single transaction, skipping
     /// streams that are not active or not owned by `sender` instead of aborting.
     /// Returns the list of successfully cancelled stream IDs.


### PR DESCRIPTION
closes #209 


- Add TierVolumeLimitExceeded = 34 error variant
- Add MerchantMonthlyVolume(Address, u32) DataKey for per-month tracking
- Add tier cap constants: Unverified 00, Basic 0k, Full 00k, Business unlimited
- Add enforce_tier_volume_cap() helper in PaymentProcessor — checks and accumulates confirmed payment amounts against the merchant's KYC tier cap
- Enforce cap in verify_payment() before confirming Confirmed/Overpaid payments
- Add 3 tests: Basic tier cap enforced, Business tier unlimited, monthly reset
- Fix pre-existing unclosed delimiter in stream.rs (missing  in close_expired_stream)

Note: CI test job will fail due to pre-existing compile errors in lib.rs (moved values, ambiguous types, missing fields in batch payment struct, etc.) that exist on main and are unrelated to this change.