### PR TITLE
feat: configure dynamic rate-limiting windows (#157)

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -296,6 +296,13 @@ pub struct PauseInfo {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitConfig {
+    pub window_secs: u64,
+    pub max_per_window: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MerchantCreateRateLimit {
     pub last_payment_at: u64,
     pub count: u32,
@@ -524,6 +531,8 @@ pub enum DataKey {
     MerchantMonthlyVolume(Address, u32),
     FeeProposal,
     CurrentFee,
+    GlobalRateLimit,
+    MerchantSpecificRateLimit(Address),
 }
 
 // When building for WASM deployment, only the active contract's #[contractimpl]
@@ -2831,9 +2840,40 @@ impl PaymentProcessor {
         env.storage()
             .persistent()
             .set(&DataKey::MerchantRegistryAddress, &registry_address);
-
         Ok(())
     }
+
+    pub fn set_global_rate_limit(
+        env: Env,
+        admin: Address,
+        window_secs: u64,
+        max_per_window: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        let config = RateLimitConfig { window_secs, max_per_window };
+        env.storage().persistent().set(&DataKey::GlobalRateLimit, &config);
+        Ok(())
+    }
+
+    pub fn set_merchant_rate_limit(
+        env: Env,
+        admin: Address,
+        merchant_id: Address,
+        window_secs: u64,
+        max_per_window: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        let config = RateLimitConfig { window_secs, max_per_window };
+        env.storage().persistent().set(&DataKey::MerchantSpecificRateLimit(merchant_id), &config);
+        Ok(())
+    }
+
 
     pub fn grant_role(
         env: Env,
@@ -2985,6 +3025,16 @@ impl PaymentProcessor {
 
     fn enforce_create_payment_rate_limit(env: &Env, merchant_id: &Address) -> Result<(), Error> {
         let now = env.ledger().timestamp();
+        
+        let config: RateLimitConfig = env.storage().persistent().get(&DataKey::MerchantSpecificRateLimit(merchant_id.clone()))
+            .unwrap_or_else(|| {
+                env.storage().persistent().get(&DataKey::GlobalRateLimit)
+                    .unwrap_or(RateLimitConfig {
+                        window_secs: CREATE_PAYMENT_WINDOW_SECS,
+                        max_per_window: CREATE_PAYMENT_MAX_PER_WINDOW,
+                    })
+            });
+
         let key = DataKey::MerchantRateLimit(merchant_id.clone());
 
         let mut state: MerchantCreateRateLimit =
@@ -2996,11 +3046,11 @@ impl PaymentProcessor {
                     count: 0,
                 });
 
-        if now.saturating_sub(state.last_payment_at) >= CREATE_PAYMENT_WINDOW_SECS {
+        if now.saturating_sub(state.last_payment_at) >= config.window_secs {
             state.count = 0;
         }
 
-        if state.count >= CREATE_PAYMENT_MAX_PER_WINDOW {
+        if state.count >= config.max_per_window {
             return Err(Error::RateLimitExceeded);
         }
 


### PR DESCRIPTION
Closes #157 

# Configure Dynamic rate-limiting windows (#157)

## Description
This PR resolves issue #157 by replacing the hardcoded `CREATE_PAYMENT_MAX_PER_WINDOW` and `CREATE_PAYMENT_WINDOW_SECS` rate limits with dynamic configurations stored in persistent storage. 

It introduces a new `RateLimitConfig` struct and adds admin capabilities to adjust limits both globally and on a per-merchant basis.

## Acceptance Criteria Met
- [x] **Store rate limit configurations in persistent storage:** Added `GlobalRateLimit` and `MerchantSpecificRateLimit` to `DataKey` alongside the `RateLimitConfig` struct.
- [x] **Admin can update limits globally or override limits for specific merchants:** Added `set_global_rate_limit` and `set_merchant_rate_limit` functions in the `PaymentProcessor` contract (restricted to admin).

## Changes Made
- Added `RateLimitConfig` struct to store `window_secs` and `max_per_window`.
- Added `GlobalRateLimit` and `MerchantSpecificRateLimit` variants to the `DataKey` enum.
- Updated `enforce_create_payment_rate_limit` in `lib.rs` to fetch the custom limit (first checking merchant overrides, falling back to global overrides, and lastly defaulting to the original 30 tx / 60 sec rule).
- Implemented `set_global_rate_limit` to define standard rate limits for all merchants.
- Implemented `set_merchant_rate_limit` to explicitly override a merchant's limit.
