### PR TITLE
[#162] [16/90] Customizable Partial Payment Logic per Merchant

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -3542,7 +3542,7 @@ impl PaymentProcessor {
 
         let diff = amount_received - payment.amount;
 
-        let new_status = if (0..=tolerance).contains(&diff) {
+        let mut new_status = if (0..=tolerance).contains(&diff) {
             // Exact match or tiny overpay within tolerance → Confirmed
             PaymentStatus::Confirmed
         } else if diff > tolerance {
@@ -3555,6 +3555,36 @@ impl PaymentProcessor {
             // Meaningfully less than expected → PartiallyPaid
             PaymentStatus::PartiallyPaid
         };
+
+        // Issue #162: Merchant-configurable partial payment policy.
+        if new_status == PaymentStatus::PartiallyPaid {
+            let partial_allowed = if let Some(registry_address) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Address>(&DataKey::MerchantRegistryAddress)
+            {
+                let registry_client =
+                    crate::merchant_registry::MerchantRegistryClient::new(&env, &registry_address);
+                match registry_client.try_get_merchant(&payment.merchant_id) {
+                    Ok(Ok(merchant)) => merchant.partial_payment_allowed,
+                    _ => false,
+                }
+            } else {
+                false
+            };
+
+            if !partial_allowed {
+                new_status = PaymentStatus::Failed;
+                env.events().publish(
+                    (
+                        Symbol::new(&env, "REFUND"),
+                        Symbol::new(&env, "AUTO_REQUIRED"),
+                        payment.merchant_id.clone(),
+                    ),
+                    (payment_id.clone(), amount_received),
+                );
+            }
+        }
 
         // Issue #63: Enforce tier-based monthly volume cap before confirming payment.
         if new_status == PaymentStatus::Confirmed || new_status == PaymentStatus::Overpaid {

--- a/fluxapay/src/merchant_registry.rs
+++ b/fluxapay/src/merchant_registry.rs
@@ -78,6 +78,8 @@ pub struct Merchant {
     pub bank_account: Option<String>,
     /// KYC tier replaces the old `verified: bool` field.
     pub kyc_tier: KycTier,
+    /// Merchant-level toggle for accepting underpayments.
+    pub partial_payment_allowed: bool,
     pub active: bool,
     pub created_at: u64,
     pub suspension_reason: Option<String>,
@@ -177,10 +179,14 @@ impl MerchantRegistry {
             payout_address,
             bank_account,
             kyc_tier: KycTier::Unverified,
+            partial_payment_allowed: false,
             active: true,
             created_at: env.ledger().timestamp(),
             suspension_reason: None,
             suspended_at: None,
+            suspension_expires_at: None,
+            oracle_signature: None,
+            last_payout_change_at: None,
             fee_config: MaybeFeeConfig::from(fee_config),
             metadata_hash: None,
             currency_payout_addresses: map![&env],
@@ -261,6 +267,28 @@ impl MerchantRegistry {
         env.events().publish(
             (Symbol::new(&env, "MERCHANT"), Symbol::new(&env, "UPDATED")),
             merchant_id,
+        );
+
+        Ok(())
+    }
+
+    /// Merchant can toggle whether partial payments are accepted.
+    pub fn set_partial_payment_allowed(
+        env: Env,
+        merchant_id: Address,
+        partial_payment_allowed: bool,
+    ) -> Result<(), MerchantError> {
+        merchant_id.require_auth();
+        let mut merchant = Self::get_merchant_internal(&env, &merchant_id)?;
+        merchant.partial_payment_allowed = partial_payment_allowed;
+
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::Merchant(merchant_id.clone()), &merchant);
+
+        env.events().publish(
+            (Symbol::new(&env, "MERCHANT"), Symbol::new(&env, "PARTIAL_PAYMENT_UPDATED")),
+            (merchant_id, partial_payment_allowed),
         );
 
         Ok(())


### PR DESCRIPTION
Closes #162

## Summary
- Added partial_payment_allowed to merchant registry profiles
- Added merchant-facing setter set_partial_payment_allowed with event emission
- Updated payment verification logic to enforce merchant partial-payment policy
- Underpayment now resolves to PartiallyPaid only if merchant allows it; otherwise payment is marked Failed and emits REFUND/AUTO_REQUIRED`n
## Validation
- Attempted cargo test --workspace; repository currently has unrelated baseline compile failures (dex_router and other modules) that block full-suite execution