### PR TITLE
feat: dispute deadline checker, stream top-up, treasury accounting, batch payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - `docs/local-invoke.md`: CLI recipe sections for `create_refund`, `process_refund`, `create_dispute`, `set_dispute_deadline`, `resolve_dispute_with_refund`, `verify_payment`, `settle_payment`, `set_paused`, `set_rate`, `create_link`, and `use_link` — each with full command, expected output, and error scenarios (closes #299)
 - `docs/local-invoke.md`: Deployment section documenting how to run `scripts/deploy_testnet.sh` and load `.env.testnet`
 
+- `check_dispute_deadline(dispute_id)`: public callable to trigger escalation when a dispute review deadline has elapsed; emits `DISPUTE/ESCALATED` and is a no-op if not passed/already escalated/resolved (closes #306)
+- `top_up_stream(stream_id, amount)`: allows a sender to top up a single stream via direct token transfer; credits the stream deposit and emits `STREAM/TOPPED_UP` (closes #305)
+- Treasury accounting: refund-time fees now accumulate in `DataKey::TreasuryBalance`; adds `get_treasury_balance()` and `withdraw_treasury(admin, amount, destination)` for admin withdrawals; emits `TREASURY/WITHDRAWN` and introduces `Error::InsufficientTreasuryBalance` (closes #291)
+- `create_payments_batch`: atomic batch payment creation API with a maximum batch size of 50 and per-merchant batch rate-limit enforcement; returns payment IDs in order and emits `PAYMENT/CREATED` for each payment (closes #293)
+
 ### Changed
 - `.github/workflows/deploy.yml`: replaced inline build and deploy steps with a call to `scripts/deploy_testnet.sh`; exposes all four contract IDs as step outputs; uploads `.env.testnet` as a workflow artifact
 

--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -3,7 +3,7 @@ use crate::{
     RefundManagerClient, RefundStatus,
 };
 use soroban_sdk::{
-    testutils::{Address as _, BytesN as _},
+    testutils::{Address as _, BytesN as _, Events as _, Ledger as _},
     token, vec, Address, BytesN, Env, String, Symbol,
 };
 
@@ -133,6 +133,62 @@ fn test_review_dispute() {
     // Verify dispute status changed
     let dispute: Dispute = refund_client.get_dispute(&dispute_id);
     assert_eq!(dispute.status, DisputeStatus::UnderReview);
+}
+
+#[test]
+fn test_check_dispute_deadline_escalates_once() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, payment_client, refund_client) = setup_contracts(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let operator = Address::generate(&env);
+
+    refund_client.grant_role(&admin, &Symbol::new(&env, "SETTLEMENT_OPERATOR"), &operator);
+
+    let payment_id = String::from_str(&env, "payment_deadline_001");
+    let amount = 750i128;
+
+    payment_client.grant_role(&admin, &Symbol::new(&env, "MERCHANT"), &merchant);
+    let args = create_payment_args(&env, &payment_id, &merchant, amount);
+    payment_client.create_payment(&args);
+
+    let transaction_hash = BytesN::from_array(&env, &[0u8; 32]);
+    let oracle = Address::generate(&env);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.verify_payment(&oracle, &payment_id, &transaction_hash, &customer, &amount);
+
+    refund_client.register_payment(&payment_id, &merchant, &amount, &Symbol::new(&env, "USDC"));
+
+    let dispute_id = refund_client.create_dispute(
+        &payment_id,
+        &amount,
+        &String::from_str(&env, "Deadline test"),
+        &String::from_str(&env, "Evidence"),
+        &customer,
+        &vec![&env],
+    );
+
+    let now = env.ledger().timestamp();
+    refund_client.set_dispute_deadline(&operator, &dispute_id, &(now + 10));
+
+    let events_after_deadline = env.events().all().len();
+
+    refund_client.check_dispute_deadline(&dispute_id);
+    let dispute = refund_client.get_dispute(&dispute_id);
+    assert!(!dispute.escalated);
+    assert_eq!(env.events().all().len(), events_after_deadline);
+
+    env.ledger().set_timestamp(now + 11);
+    refund_client.check_dispute_deadline(&dispute_id);
+
+    let escalated = refund_client.get_dispute(&dispute_id);
+    assert!(escalated.escalated);
+    assert_eq!(env.events().all().len(), events_after_deadline + 1);
+
+    refund_client.check_dispute_deadline(&dispute_id);
+    assert_eq!(env.events().all().len(), events_after_deadline + 1);
 }
 
 #[test]

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -249,6 +249,8 @@ pub enum Error {
     RefundCooldownNotElapsed = 42,
     /// Refund request has expired and cannot be processed.
     RefundExpired = 36,
+    /// Batch payment request exceeds the supported maximum size.
+    BatchTooLarge = 35,
     /// Insufficient arbitrators available for voting.
     InsufficientArbitrators = 37,
     /// Voting threshold not met for dispute resolution.
@@ -265,6 +267,8 @@ pub enum Error {
     StaleOracleRate = 45,
     /// Issue #313: Reentrancy detected in process_refund_internal or settle_payment.
     Reentrancy = 43,
+    /// Treasury balance is smaller than the requested withdrawal amount.
+    InsufficientTreasuryBalance = 46,
 }
 
 #[contracttype]
@@ -561,6 +565,7 @@ pub enum DataKey {
     PaymentDisputes(String),
     DisputeCounter,
     Stream(String),
+    TreasuryBalance,
     UsdcToken,
     Paused,
     CreationPaused,
@@ -1154,6 +1159,56 @@ impl RefundManager {
         Self::process_refund_internal(&env, &operator, refund_id)
     }
 
+    pub fn get_treasury_balance(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TreasuryBalance)
+            .unwrap_or(0)
+    }
+
+    pub fn withdraw_treasury(
+        env: Env,
+        admin: Address,
+        amount: i128,
+        destination: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let treasury_balance = Self::get_treasury_balance(env.clone());
+        if amount > treasury_balance {
+            return Err(Error::InsufficientTreasuryBalance);
+        }
+
+        let usdc_token_address: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UsdcToken)
+            .ok_or(Error::Unauthorized)?;
+        let token_client = token::TokenClient::new(&env, &usdc_token_address);
+        let contract_address = env.current_contract_address();
+
+        env.storage().persistent().set(
+            &DataKey::TreasuryBalance,
+            &treasury_balance.saturating_sub(amount),
+        );
+
+        token_client.transfer(&contract_address, &destination, &amount);
+
+        env.events().publish(
+            (Symbol::new(&env, "TREASURY"), Symbol::new(&env, "WITHDRAWN")),
+            (amount, destination),
+        );
+
+        Ok(())
+    }
+
     fn process_refund_internal(
         env: &Env,
         _operator: &Address,
@@ -1287,41 +1342,12 @@ impl RefundManager {
             return Ok(());
         }
 
-        // Issue #168: Fee split destinations
         if fee > 0 {
-            let fee_split: Option<FeeSplitConfig> = env
-                .storage()
-                .persistent()
-                .get(&DataKey::FeeSplitConfig);
-            
-            if let Some(config) = fee_split {
-                // Validate split adds up to 100%
-                if config.treasury_bps + config.developer_bps == 10_000 {
-                    let treasury_fee = fee * config.treasury_bps as i128 / 10_000;
-                    let developer_fee = fee * config.developer_bps as i128 / 10_000;
-                    
-                    if treasury_fee > 0 {
-                        let treasury_muxed: MuxedAddress = (&config.treasury_address).into();
-                        let _ = token_client.try_transfer(&from, &treasury_muxed, &treasury_fee);
-                    }
-                    if developer_fee > 0 {
-                        let developer_muxed: MuxedAddress = (&config.developer_address).into();
-                        let _ = token_client.try_transfer(&from, &developer_muxed, &developer_fee);
-                    }
-                } else {
-                    // Fallback to admin if config is invalid
-                    if let Some(admin) = AccessControl::get_admin(env) {
-                        let admin_muxed: MuxedAddress = (&admin).into();
-                        let _ = token_client.try_transfer(&from, &admin_muxed, &fee);
-                    }
-                }
-            } else {
-                // No fee split configured, send to admin
-                if let Some(admin) = AccessControl::get_admin(env) {
-                    let admin_muxed: MuxedAddress = (&admin).into();
-                    let _ = token_client.try_transfer(&from, &admin_muxed, &fee);
-                }
-            }
+            let current_treasury_balance = Self::get_treasury_balance(env.clone());
+            env.storage().persistent().set(
+                &DataKey::TreasuryBalance,
+                &current_treasury_balance.saturating_add(fee),
+            );
         }
         
         env.events().publish(
@@ -1893,6 +1919,44 @@ impl RefundManager {
             (dispute.payment_id, dispute_id, deadline),
         );
 
+        Ok(())
+    }
+
+    fn maybe_escalate_dispute_due_to_deadline(
+        env: &Env,
+        dispute_id: &String,
+        dispute: &mut Dispute,
+    ) -> Result<bool, Error> {
+        if dispute.status == DisputeStatus::Resolved || dispute.status == DisputeStatus::Rejected {
+            return Ok(false);
+        }
+
+        let Some(deadline) = dispute.review_deadline else {
+            return Ok(false);
+        };
+
+        let now = env.ledger().timestamp();
+        if now <= deadline || dispute.escalated {
+            return Ok(false);
+        }
+
+        dispute.escalated = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(dispute_id.clone()), &dispute);
+        Self::bump_dispute_ttl(env, dispute_id, &dispute.status);
+        env.events().publish(
+            (Symbol::new(env, "DISPUTE"), Symbol::new(env, "ESCALATED")),
+            (dispute.payment_id.clone(), dispute_id.clone(), dispute.amount),
+        );
+
+        Ok(true)
+    }
+
+    /// Anyone may call this to trigger escalation after a dispute review deadline elapses.
+    pub fn check_dispute_deadline(env: Env, dispute_id: String) -> Result<(), Error> {
+        let mut dispute = Self::get_dispute_internal(&env, &dispute_id)?;
+        let _ = Self::maybe_escalate_dispute_due_to_deadline(&env, &dispute_id, &mut dispute)?;
         Ok(())
     }
 
@@ -2572,24 +2636,7 @@ impl RefundManager {
 
     pub fn get_dispute(env: Env, dispute_id: String) -> Result<Dispute, Error> {
         let mut dispute = Self::get_dispute_internal(&env, &dispute_id)?;
-        let now = env.ledger().timestamp();
-        if let Some(deadline) = dispute.review_deadline {
-            if now > deadline
-                && !dispute.escalated
-                && dispute.status != DisputeStatus::Resolved
-                && dispute.status != DisputeStatus::Rejected
-            {
-                dispute.escalated = true;
-                env.storage()
-                    .persistent()
-                    .set(&DataKey::Dispute(dispute_id.clone()), &dispute);
-                Self::bump_dispute_ttl(&env, &dispute_id, &dispute.status);
-                env.events().publish(
-                    (Symbol::new(&env, "DISPUTE"), Symbol::new(&env, "ESCALATED")),
-                    (dispute.payment_id.clone(), dispute_id, dispute.amount),
-                );
-            }
-        }
+        let _ = Self::maybe_escalate_dispute_due_to_deadline(&env, &dispute_id, &mut dispute)?;
         Ok(dispute)
     }
 
@@ -3915,6 +3962,54 @@ impl PaymentProcessor {
         Ok(())
     }
 
+    fn enforce_create_payment_batch_rate_limit(
+        env: &Env,
+        merchant_id: &Address,
+    ) -> Result<(), Error> {
+        let now = env.ledger().timestamp();
+
+        let config: RateLimitConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MerchantSpecificRateLimit(merchant_id.clone()))
+            .unwrap_or_else(|| {
+                env.storage()
+                    .persistent()
+                    .get(&DataKey::GlobalRateLimit)
+                    .unwrap_or(RateLimitConfig {
+                        window_secs: CREATE_PAYMENT_WINDOW_SECS,
+                        max_per_window: CREATE_PAYMENT_MAX_PER_WINDOW,
+                    })
+            });
+
+        let key = DataKey::MerchantRateLimit(merchant_id.clone());
+
+        let mut state: MerchantCreateRateLimit = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(MerchantCreateRateLimit {
+                last_payment_at: now,
+                count: 0,
+            });
+
+        if now.saturating_sub(state.last_payment_at) >= config.window_secs {
+            state.count = 0;
+        }
+
+        if state.count >= config.max_per_window {
+            return Err(Error::RateLimitExceeded);
+        }
+
+        state.count = state.count.saturating_add(1);
+        state.last_payment_at = now;
+
+        env.storage().persistent().set(&key, &state);
+        Self::bump_ttl(env, &key, SHORT_LIVE_TTL);
+
+        Ok(())
+    }
+
     /// Set per-merchant min/max payment amount limits (merchant self-service).
     /// Pass None to clear a bound. Requires the caller to hold the MERCHANT role.
     pub fn set_merchant_amount_limits(
@@ -4337,15 +4432,25 @@ impl PaymentProcessor {
     ) -> Result<Vec<String>, Error> {
         Self::require_creation_not_paused(&env)?;
 
+        if args_list.len() > 50 {
+            return Err(Error::BatchTooLarge);
+        }
+
         if args_list.is_empty() {
             return Ok(vec![&env]);
         }
+
+        let mut batch_merchants: Vec<Address> = vec![&env];
 
         // Validate all payments first before creating any
         for args in args_list.iter() {
             args.merchant_id.require_auth();
             Self::require_not_blacklisted(&env, &args.merchant_id)?;
             Self::require_not_blacklisted(&env, &args.deposit_address)?;
+
+            if !batch_merchants.contains(&args.merchant_id) {
+                batch_merchants.push_back(args.merchant_id.clone());
+            }
 
             // Verify merchant role
             if !AccessControl::has_role(&env, &role_merchant(&env), &args.merchant_id) {
@@ -4440,14 +4545,15 @@ impl PaymentProcessor {
             }
         }
 
+        for merchant_id in batch_merchants.iter() {
+            Self::enforce_create_payment_batch_rate_limit(&env, merchant_id)?;
+        }
+
         // All validations passed, now create all payments
         let mut payment_ids = vec![&env];
         let now = env.ledger().timestamp();
 
         for args in args_list.iter() {
-            // Rate limit check per merchant
-            Self::enforce_create_payment_rate_limit(&env, &args.merchant_id)?;
-
             let resolved_expires_at = match args.expires_at {
                 Some(ts) => ts,
                 None => now.saturating_add(args.duration_secs.unwrap_or(DEFAULT_PAYMENT_DURATION_SECS)),
@@ -5614,6 +5720,15 @@ impl PaymentProcessor {
         top_ups: Vec<(String, i128)>,
     ) -> Result<(), StreamError> {
         PaymentStreaming::top_up_multiple_streams(env, sender, top_ups)
+    }
+
+    pub fn top_up_stream(
+        env: Env,
+        sender: Address,
+        stream_id: String,
+        amount: i128,
+    ) -> Result<(), StreamError> {
+        PaymentStreaming::top_up_stream(env, sender, stream_id, amount)
     }
 
     /// Update the flow rate of an active stream (increase or decrease).

--- a/fluxapay/src/stream.rs
+++ b/fluxapay/src/stream.rs
@@ -764,45 +764,63 @@ impl PaymentStreaming {
 
         for top_up in top_ups.iter() {
             let (stream_id, amount) = top_up;
-            if amount <= 0 {
-                return Err(StreamError::InvalidDeposit);
-            }
-
-            let mut stream: PaymentStream = env
-                .storage()
-                .persistent()
-                .get(&StreamDataKey::Stream(stream_id.clone()))
-                .ok_or(StreamError::StreamNotFound)?;
-
-            if stream.sender != sender {
-                return Err(StreamError::Unauthorized);
-            }
-            if stream.status != StreamStatus::Active {
-                return Err(StreamError::StreamNotActive);
-            }
-
-            // Effects
-            stream.remaining_deposit = stream.remaining_deposit.saturating_add(amount);
-
-            // Persist state before interaction
-            env.storage()
-                .persistent()
-                .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
-
-            // Interaction
-            let token_client = token::Client::new(&env, &stream.token);
-            token_client.transfer(&sender, env.current_contract_address(), &amount);
-
-            // Event
-            env.events().publish(
-                (
-                    Symbol::new(&env, "STREAM"),
-                    Symbol::new(&env, "TOPPED_UP"),
-                    stream_id,
-                ),
-                (sender.clone(), amount),
-            );
+            Self::top_up_stream_internal(&env, &sender, stream_id, *amount)?;
         }
+
+        Ok(())
+    }
+
+    pub fn top_up_stream(
+        env: Env,
+        sender: Address,
+        stream_id: String,
+        amount: i128,
+    ) -> Result<(), StreamError> {
+        sender.require_auth();
+
+        Self::top_up_stream_internal(&env, &sender, &stream_id, amount)
+    }
+
+    fn top_up_stream_internal(
+        env: &Env,
+        sender: &Address,
+        stream_id: &String,
+        amount: i128,
+    ) -> Result<(), StreamError> {
+        if amount <= 0 {
+            return Err(StreamError::InvalidDeposit);
+        }
+
+        let mut stream: PaymentStream = env
+            .storage()
+            .persistent()
+            .get(&StreamDataKey::Stream(stream_id.clone()))
+            .ok_or(StreamError::StreamNotFound)?;
+
+        if stream.sender != *sender {
+            return Err(StreamError::Unauthorized);
+        }
+        if stream.status != StreamStatus::Active {
+            return Err(StreamError::StreamNotActive);
+        }
+
+        stream.remaining_deposit = stream.remaining_deposit.saturating_add(amount);
+
+        env.storage()
+            .persistent()
+            .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
+
+        let token_client = token::Client::new(env, &stream.token);
+        token_client.transfer(sender, env.current_contract_address(), &amount);
+
+        env.events().publish(
+            (
+                Symbol::new(env, "STREAM"),
+                Symbol::new(env, "TOPPED_UP"),
+                stream_id.clone(),
+            ),
+            (sender.clone(), amount),
+        );
 
         Ok(())
     }

--- a/fluxapay/src/stream_test.rs
+++ b/fluxapay/src/stream_test.rs
@@ -323,6 +323,51 @@ fn test_withdrawn_event_includes_remaining_deposit() {
 }
 
 #[test]
+fn test_top_up_stream_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, sender, receiver, token) = setup(&env);
+    let token_client = token::StellarAssetClient::new(&env, &token);
+
+    let stream_id = String::from_str(&env, "stream_top_up");
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id);
+
+    client.top_up_stream(&sender, &stream_id, &250i128);
+
+    let stream = client.get_stream(&stream_id);
+    assert_eq!(stream.remaining_deposit, 750);
+    assert_eq!(token_client.balance(&client.address), 750i128);
+}
+
+#[test]
+fn test_top_up_stream_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, sender, receiver, token) = setup(&env);
+
+    let stream_id = String::from_str(&env, "stream_top_up_auth");
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id);
+
+    let impostor = Address::generate(&env);
+    let result = client.try_top_up_stream(&impostor, &stream_id, &50i128);
+    assert_eq!(result, Err(Ok(StreamError::Unauthorized)));
+}
+
+#[test]
+fn test_top_up_stream_rejects_inactive_stream() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, sender, receiver, token) = setup(&env);
+
+    let stream_id = String::from_str(&env, "stream_top_up_inactive");
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id);
+    client.cancel_stream(&sender, &stream_id);
+
+    let result = client.try_top_up_stream(&sender, &stream_id, &50i128);
+    assert_eq!(result, Err(Ok(StreamError::StreamNotActive)));
+}
+
+#[test]
 fn test_decrease_rate_to_exactly_min_rate_succeeds() {
     let env = Env::default();
     env.mock_all_auths();

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -52,6 +52,23 @@ fn setup_refund_manager(env: &Env) -> (Address, RefundManagerClient<'_>) {
     (admin, client)
 }
 
+fn setup_refund_manager_with_token(env: &Env) -> (Address, RefundManagerClient<'_>, Address) {
+    let contract_id = env.register(RefundManager, ());
+    let client = RefundManagerClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+
+    let token_admin = Address::generate(env);
+    let usdc_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.initialize_refund_manager(&admin, &usdc_token);
+
+    let token_admin_client = token::StellarAssetClient::new(env, &usdc_token);
+    token_admin_client.mint(&contract_id, &1_000_000_000_000i128);
+
+    (admin, client, usdc_token)
+}
+
 fn create_payment_args(
     env: &Env,
     payment_id: &String,
@@ -141,6 +158,72 @@ fn test_create_payment_rate_limit_enforced() {
     let overflow = client.try_create_payment(&args);
 
     assert_eq!(overflow, Err(Ok(Error::RateLimitExceeded)));
+}
+
+#[test]
+fn test_create_payments_batch_returns_ids_in_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let payment_id_1 = String::from_str(&env, "batch_payment_1");
+    let payment_id_2 = String::from_str(&env, "batch_payment_2");
+    let batch = vec![
+        &env,
+        create_payment_args(&env, &payment_id_1, &merchant_id, 100i128),
+        create_payment_args(&env, &payment_id_2, &merchant_id, 200i128),
+    ];
+
+    let payment_ids = client.create_payments_batch(&batch);
+
+    assert_eq!(payment_ids.len(), 2);
+    assert_eq!(payment_ids.get(0).unwrap(), payment_id_1);
+    assert_eq!(payment_ids.get(1).unwrap(), payment_id_2);
+}
+
+#[test]
+fn test_create_payments_batch_rejects_oversized_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let mut batch = vec![&env];
+    for i in 0..51u32 {
+        let payment_id = format_id(&env, "batch_limit_", i as u64);
+        batch.push_back(create_payment_args(&env, &payment_id, &merchant_id, 100i128));
+    }
+
+    let result = client.try_create_payments_batch(&batch);
+    assert_eq!(result, Err(Ok(Error::BatchTooLarge)));
+}
+
+#[test]
+fn test_create_payments_batch_is_atomic_on_validation_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+
+    let payment_id_1 = String::from_str(&env, "batch_atomic_1");
+    let payment_id_2 = String::from_str(&env, "batch_atomic_2");
+    let batch = vec![
+        &env,
+        create_payment_args(&env, &payment_id_1, &merchant_id, 100i128),
+        create_payment_args(&env, &payment_id_2, &merchant_id, 0i128),
+    ];
+
+    let result = client.try_create_payments_batch(&batch);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    assert!(!env.storage().persistent().has(&DataKey::Payment(payment_id_1)));
+    assert!(!env.storage().persistent().has(&DataKey::Payment(payment_id_2)));
 }
 
 #[test]
@@ -662,6 +745,63 @@ fn test_process_refund() {
 
     let refund = client.get_refund(&refund_id);
     assert_eq!(refund.status, RefundStatus::Completed);
+}
+
+#[test]
+fn test_process_refund_accumulates_treasury_and_withdraws() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client, usdc_token) = setup_refund_manager_with_token(&env);
+    let token_client = token::StellarAssetClient::new(&env, &usdc_token);
+
+    let merchant_id = Address::generate(&env);
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_settlement_operator(&env), &operator);
+
+    let payment_ids = ["refund_treasury_a", "refund_treasury_b"];
+    for payment_suffix in payment_ids.iter() {
+        let payment_id = String::from_str(&env, payment_suffix);
+        let requester = Address::generate(&env);
+
+        client.register_payment(
+            &payment_id,
+            &merchant_id,
+            &5000i128,
+            &Symbol::new(&env, "USDC"),
+        );
+
+        let refund_id = client.create_refund(
+            &payment_id,
+            &1000i128,
+            &String::from_str(&env, "Reason"),
+            &requester,
+        );
+
+        client.process_refund(&operator, &refund_id);
+    }
+
+    assert_eq!(client.get_treasury_balance(), 20i128);
+
+    let destination = Address::generate(&env);
+    let starting_balance = token_client.balance(&destination);
+
+    client.withdraw_treasury(&admin, &15i128, &destination);
+
+    assert_eq!(client.get_treasury_balance(), 5i128);
+    assert_eq!(token_client.balance(&destination), starting_balance + 15i128);
+}
+
+#[test]
+fn test_withdraw_treasury_rejects_insufficient_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client, _usdc_token) = setup_refund_manager_with_token(&env);
+
+    let destination = Address::generate(&env);
+    let result = client.try_withdraw_treasury(&admin, &1i128, &destination);
+
+    assert_eq!(result, Err(Ok(Error::InsufficientTreasuryBalance)));
+    assert_eq!(client.get_treasury_balance(), 0i128);
 }
 
 #[test]


### PR DESCRIPTION
This PR implements the following changes:

- Add `check_dispute_deadline(dispute_id)` callable by anyone to trigger escalation when a dispute review deadline has elapsed.
- Add `top_up_stream(stream_id, amount)` to allow single-stream top-ups via direct token transfer.
- Replace refund-time fee direct-transfer with accumulation in `TreasuryBalance`, add `get_treasury_balance()` and `withdraw_treasury(admin, amount, destination)` with `TREASURY/WITHDRAWN` event.
- Implement `create_payments_batch` guardrails: batch size limit (50) and atomic validation with per-merchant batch rate-limit counting.

Closes #306, Closes #305, Closes #291, Closes #293