### PR TITLE
Track merchant payout address history

### DIFF
--- a/fluxapay/src/merchant_registry.rs
+++ b/fluxapay/src/merchant_registry.rs
@@ -100,6 +100,7 @@ pub struct Merchant {
 #[contracttype]
 pub enum MerchantDataKey {
     Merchant(Address),
+    MerchantPayoutHistory(Address),
     Admin,
     /// Stores the list of all registered merchants for enumeration
     MerchantList,
@@ -229,31 +230,57 @@ impl MerchantRegistry {
             merchant.active = is_active;
         }
         if let Some(addr) = payout_address {
-            // Validate against whitelist if whitelist is not empty (issue #210)
-            if !merchant.payout_whitelist.is_empty() {
-                let mut is_whitelisted = false;
-                for whitelisted_addr in merchant.payout_whitelist.iter() {
-                    if whitelisted_addr == addr {
-                        is_whitelisted = true;
-                        break;
+            let previous_payout_address = merchant.payout_address.clone();
+            let payout_changed = previous_payout_address
+                .as_ref()
+                .map_or(true, |previous_addr| previous_addr != &addr);
+
+            if payout_changed {
+                // Validate against whitelist if whitelist is not empty (issue #210)
+                if !merchant.payout_whitelist.is_empty() {
+                    let mut is_whitelisted = false;
+                    for whitelisted_addr in merchant.payout_whitelist.iter() {
+                        if whitelisted_addr == addr {
+                            is_whitelisted = true;
+                            break;
+                        }
+                    }
+                    if !is_whitelisted {
+                        return Err(MerchantError::PayoutAddressNotWhitelisted);
                     }
                 }
-                if !is_whitelisted {
-                    return Err(MerchantError::PayoutAddressNotWhitelisted);
+
+                // Enforce 48-hour delay on payout address changes (issue #212)
+                let current_time = env.ledger().timestamp();
+                let forty_eight_hours = 48 * 60 * 60; // 48 hours in seconds
+                if let Some(last_change_time) = merchant.last_payout_change_at {
+                    if current_time < last_change_time + forty_eight_hours {
+                        return Err(MerchantError::Unauthorized); // Reuse Unauthorized error or create new one
+                    }
                 }
-            }
-            
-            // Enforce 48-hour delay on payout address changes (issue #212)
-            let current_time = env.ledger().timestamp();
-            let forty_eight_hours = 48 * 60 * 60; // 48 hours in seconds
-            if let Some(last_change_time) = merchant.last_payout_change_at {
-                if current_time < last_change_time + forty_eight_hours {
-                    return Err(MerchantError::Unauthorized); // Reuse Unauthorized error or create new one
+
+                if let Some(old_addr) = previous_payout_address {
+                    let history_key = MerchantDataKey::MerchantPayoutHistory(merchant_id.clone());
+                    let mut history: Vec<Address> = env
+                        .storage()
+                        .persistent()
+                        .get(&history_key)
+                        .unwrap_or_else(|| vec![&env]);
+                    history.push_back(old_addr.clone());
+                    env.storage().persistent().set(&history_key, &history);
+
+                    env.events().publish(
+                        (
+                            Symbol::new(&env, "MERCHANT"),
+                            Symbol::new(&env, "PAYOUT_UPDATED"),
+                        ),
+                        (merchant_id.clone(), old_addr, addr.clone()),
+                    );
                 }
+
+                merchant.payout_address = Some(addr);
+                merchant.last_payout_change_at = Some(current_time);
             }
-            
-            merchant.payout_address = Some(addr);
-            merchant.last_payout_change_at = Some(current_time);
         }
         if let Some(acct) = bank_account {
             merchant.bank_account = Some(acct);
@@ -327,6 +354,20 @@ impl MerchantRegistry {
 
         let merchant = Self::get_merchant_internal(&env, &merchant_id)?;
         Ok(merchant.bank_account)
+    }
+
+    /// Get the previous payout addresses for a merchant in chronological order.
+    pub fn get_payout_history(
+        env: Env,
+        merchant_id: Address,
+    ) -> Result<Vec<Address>, MerchantError> {
+        Self::get_merchant_internal(&env, &merchant_id)?;
+
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&MerchantDataKey::MerchantPayoutHistory(merchant_id))
+            .unwrap_or_else(|| vec![&env]))
     }
 
     /// Verify merchant (admin only) — sets KycTier::Basic for backward compatibility.

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -638,6 +638,161 @@ fn test_payout_address_rotation_delay_success_after_48_hours() {
 }
 
 #[test]
+fn test_payout_history_initially_empty_after_first_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MerchantRegistry, ());
+    let client = MerchantRegistryClient::new(&env, &contract_id);
+
+    let merchant_id = Address::generate(&env);
+    client.register_merchant(
+        &merchant_id,
+        &String::from_str(&env, "Merchant"),
+        &String::from_str(&env, "USDC"),
+        &None,
+        &None,
+        &None,
+    );
+
+    let events_before = env.events().all().len();
+    let payout_addr = Address::generate(&env);
+    client.update_merchant(
+        &merchant_id,
+        &None,
+        &None,
+        &None,
+        &Some(payout_addr),
+        &None,
+        &None,
+    );
+
+    let history = client.get_payout_history(&merchant_id);
+    assert_eq!(history.len(), 0);
+    assert_eq!(env.events().all().len(), events_before + 1);
+}
+
+#[test]
+fn test_payout_history_records_previous_addresses_in_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MerchantRegistry, ());
+    let client = MerchantRegistryClient::new(&env, &contract_id);
+
+    let merchant_id = Address::generate(&env);
+    client.register_merchant(
+        &merchant_id,
+        &String::from_str(&env, "Merchant"),
+        &String::from_str(&env, "USDC"),
+        &None,
+        &None,
+        &None,
+    );
+
+    let payout_addr1 = Address::generate(&env);
+    let payout_addr2 = Address::generate(&env);
+    let payout_addr3 = Address::generate(&env);
+
+    client.update_merchant(
+        &merchant_id,
+        &None,
+        &None,
+        &None,
+        &Some(payout_addr1.clone()),
+        &None,
+        &None,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp += 48 * 60 * 60 + 1);
+    let events_before_second_update = env.events().all().len();
+    client.update_merchant(
+        &merchant_id,
+        &None,
+        &None,
+        &None,
+        &Some(payout_addr2.clone()),
+        &None,
+        &None,
+    );
+
+    let history_after_second_update = client.get_payout_history(&merchant_id);
+    assert_eq!(history_after_second_update.len(), 1);
+    assert_eq!(history_after_second_update.get(0).unwrap(), payout_addr1.clone());
+    assert_eq!(
+        env.events().all().len(),
+        events_before_second_update + 2
+    );
+
+    env.ledger().with_mut(|li| li.timestamp += 48 * 60 * 60 + 1);
+    client.update_merchant(
+        &merchant_id,
+        &None,
+        &None,
+        &None,
+        &Some(payout_addr3),
+        &None,
+        &None,
+    );
+
+    let history = client.get_payout_history(&merchant_id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap(), payout_addr1);
+    assert_eq!(history.get(1).unwrap(), payout_addr2);
+}
+
+#[test]
+fn test_unchanged_payout_address_does_not_add_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MerchantRegistry, ());
+    let client = MerchantRegistryClient::new(&env, &contract_id);
+
+    let merchant_id = Address::generate(&env);
+    client.register_merchant(
+        &merchant_id,
+        &String::from_str(&env, "Merchant"),
+        &String::from_str(&env, "USDC"),
+        &None,
+        &None,
+        &None,
+    );
+
+    let payout_addr = Address::generate(&env);
+    client.update_merchant(
+        &merchant_id,
+        &None,
+        &None,
+        &None,
+        &Some(payout_addr.clone()),
+        &None,
+        &None,
+    );
+
+    let new_name = String::from_str(&env, "Merchant renamed");
+    let events_before_same_address_update = env.events().all().len();
+    client.update_merchant(
+        &merchant_id,
+        &Some(new_name.clone()),
+        &None,
+        &None,
+        &Some(payout_addr.clone()),
+        &None,
+        &None,
+    );
+
+    let merchant = client.get_merchant(&merchant_id);
+    assert_eq!(merchant.business_name, new_name);
+    assert_eq!(merchant.payout_address, Some(payout_addr));
+    assert_eq!(client.get_payout_history(&merchant_id).len(), 0);
+    assert_eq!(
+        env.events().all().len(),
+        events_before_same_address_update + 1
+    );
+}
+
+#[test]
 #[should_panic(expected = "HostError: Error(Contract, #3)")]
 fn test_suspend_merchant_unauthorized() {
     let env = Env::default();


### PR DESCRIPTION
## Summary
- add persistent merchant payout address history keyed by merchant id
- record previous payout addresses only when the payout address actually changes
- emit `MERCHANT/PAYOUT_UPDATED` with `(merchant_id, old_address, new_address)` and add `get_payout_history`
- cover first-time set, ordered history retrieval, and unchanged-address updates

/claim #279

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`

## Verification
- `git diff --check`
- Not run: `cargo test -p fluxapay merchant_registry -- --nocapture` because this local environment does not have `cargo`/`rustc` installed.