### PR TITLE
Add merchant payment status filter

### DIFF
--- a/docs/local-invoke.md
+++ b/docs/local-invoke.md
@@ -690,8 +690,13 @@ stellar contract invoke \
   -- get_merchant_payments_paginated \
   --merchant_id $TEST_MERCHANT_ADDRESS \
   --offset 0 \
-  --limit 10
+  --limit 10 \
+  --status_filter null
 ```
+
+Set `status_filter` to a `PaymentStatus` value such as `Pending` or
+`Confirmed` to paginate only matching merchant payment IDs. Use `null` to
+preserve the unfiltered behavior.
 
 ### Monitor Payment Events
 

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -4878,19 +4878,36 @@ impl PaymentProcessor {
         merchant_id: Address,
         offset: u32,
         limit: u32,
+        status_filter: Option<PaymentStatus>,
     ) -> Vec<String> {
         let all = Self::get_merchant_payments_internal(&env, &merchant_id);
         if limit == 0 {
             return vec![&env];
         }
 
+        let mut filtered = vec![&env];
+        for id in all.iter() {
+            let matches_filter = match &status_filter {
+                Some(status) => env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, PaymentCharge>(&DataKey::Payment(id.clone()))
+                    .map_or(false, |payment| payment.status == status.clone()),
+                None => true,
+            };
+
+            if matches_filter {
+                filtered.push_back(id);
+            }
+        }
+
         let mut page = vec![&env];
         let start = offset;
-        let end = core::cmp::min(all.len(), start.saturating_add(limit));
+        let end = core::cmp::min(filtered.len(), start.saturating_add(limit));
 
         let mut i = start;
         while i < end {
-            if let Some(id) = all.get(i) {
+            if let Some(id) = filtered.get(i) {
                 page.push_back(id);
             }
             i += 1;

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -562,10 +562,93 @@ fn test_get_merchant_payments_index_and_pagination() {
     assert_eq!(all.get(1), Some(payment_id_2.clone()));
     assert_eq!(all.get(2), Some(payment_id_3.clone()));
 
-    let page = client.get_merchant_payments_paginated(&merchant_id, &1u32, &2u32);
+    let page =
+        client.get_merchant_payments_paginated(&merchant_id, &1u32, &2u32, &None::<PaymentStatus>);
     assert_eq!(page.len(), 2);
     assert_eq!(page.get(0), Some(payment_id_2));
     assert_eq!(page.get(1), Some(payment_id_3));
+}
+
+#[test]
+fn test_get_merchant_payments_paginated_filters_by_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    let merchant_id = Address::generate(&env);
+    let payment_id_1 = String::from_str(&env, "status_filter_1");
+    let payment_id_2 = String::from_str(&env, "status_filter_2");
+    let payment_id_3 = String::from_str(&env, "status_filter_3");
+
+    client.grant_role(&admin, &role_merchant(&env), &merchant_id);
+    client.create_payment(&create_payment_args(
+        &env,
+        &payment_id_1,
+        &merchant_id,
+        100i128,
+    ));
+    client.create_payment(&create_payment_args(
+        &env,
+        &payment_id_2,
+        &merchant_id,
+        200i128,
+    ));
+    client.create_payment(&create_payment_args(
+        &env,
+        &payment_id_3,
+        &merchant_id,
+        300i128,
+    ));
+
+    let oracle = Address::generate(&env);
+    client.grant_role(&admin, &role_oracle(&env), &oracle);
+    client.verify_payment(
+        &oracle,
+        &payment_id_2,
+        &BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &200i128,
+    );
+
+    let all =
+        client.get_merchant_payments_paginated(&merchant_id, &0u32, &10u32, &None::<PaymentStatus>);
+    assert_eq!(all.len(), 3);
+
+    let pending = client.get_merchant_payments_paginated(
+        &merchant_id,
+        &0u32,
+        &10u32,
+        &Some(PaymentStatus::Pending),
+    );
+    assert_eq!(pending.len(), 2);
+    assert_eq!(pending.get(0), Some(payment_id_1));
+    assert_eq!(pending.get(1), Some(payment_id_3.clone()));
+
+    let confirmed = client.get_merchant_payments_paginated(
+        &merchant_id,
+        &0u32,
+        &10u32,
+        &Some(PaymentStatus::Confirmed),
+    );
+    assert_eq!(confirmed.len(), 1);
+    assert_eq!(confirmed.get(0), Some(payment_id_2));
+
+    let paged_pending = client.get_merchant_payments_paginated(
+        &merchant_id,
+        &1u32,
+        &1u32,
+        &Some(PaymentStatus::Pending),
+    );
+    assert_eq!(paged_pending.len(), 1);
+    assert_eq!(paged_pending.get(0), Some(payment_id_3));
+
+    let settled = client.get_merchant_payments_paginated(
+        &merchant_id,
+        &0u32,
+        &10u32,
+        &Some(PaymentStatus::Settled),
+    );
+    assert_eq!(settled.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `status_filter: Option<PaymentStatus>` to `get_merchant_payments_paginated`
- filter stored merchant payment IDs by `PaymentCharge.status` before applying pagination
- preserve unfiltered behavior with `None`
- add coverage for unfiltered, pending, confirmed, pagination-after-filtering, and empty-result cases
- update local invoke docs with the new optional filter argument

/claim #280

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`

## Verification
- `git diff --check`
- Not run: `cargo test -p fluxapay test_get_merchant_payments_paginated -- --nocapture` because this local environment does not have `cargo`/`rustc` installed.