### PR TITLE
feat: add PaymentCharge metadata field and normalize event schema (#2…

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,456 @@
+# FluxaPay On-Chain Event Catalog
+
+All events use a **2-tuple topic** `(namespace: Symbol, action: Symbol)` and are emitted via
+`env.events().publish((namespace, action), payload)`.
+
+---
+
+## PAYMENT
+
+### PAYMENT / CREATED
+
+Emitted by `create_payment`, `create_payments_batch`, and internal subscription billing.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Unique payment identifier |
+| `merchant_id` | `Address` | Merchant receiving the payment |
+| `amount` | `i128` | Payment amount (in token minor units) |
+| `metadata` | `Option<Map<String,String>>` | Caller-supplied key/value metadata (max 20 keys, 256 chars/value) |
+
+**Example payload:**
+```
+("pay_abc123", GA…MERCHANT, 1000000, Some({"order_id": "ORD-9"}))
+```
+
+---
+
+### PAYMENT / CONFIRMED
+
+Emitted by `verify_payment` when a payment deposit is confirmed.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Payment identifier |
+| `merchant_id` | `Address` | Merchant |
+| `amount` | `i128` | Confirmed amount |
+
+---
+
+### PAYMENT / SETTLED
+
+Emitted by `settle_payment` when funds are released to the merchant.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Payment identifier |
+| `merchant_id` | `Address` | Merchant |
+| `net_amount` | `i128` | Amount after fees |
+
+---
+
+### PAYMENT / EXPIRED
+
+Emitted by `expire_payment`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Payment identifier |
+
+---
+
+## REFUND
+
+### REFUND / REQUESTED
+
+Emitted when a refund is initiated.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `refund_id` | `String` | Refund identifier |
+| `payment_id` | `String` | Original payment |
+| `amount` | `i128` | Requested refund amount |
+| `requester` | `Address` | Who requested the refund |
+
+---
+
+### REFUND / PROCESSED
+
+Emitted when a refund is executed.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `refund_id` | `String` | Refund identifier |
+| `payment_id` | `String` | Original payment |
+| `amount` | `i128` | Refunded amount |
+
+---
+
+### REFUND / REJECTED
+
+Emitted when a refund is rejected.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `refund_id` | `String` | Refund identifier |
+| `payment_id` | `String` | Original payment |
+
+---
+
+## DISPUTE
+
+### DISPUTE / CREATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Disputed payment |
+| `dispute_id` | `String` | Dispute identifier |
+| `amount` | `i128` | Disputed amount |
+
+---
+
+### DISPUTE / REVIEWED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Payment |
+| `dispute_id` | `String` | Dispute |
+
+---
+
+### DISPUTE / RESOLVED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Payment |
+| `dispute_id` | `String` | Dispute |
+| `ruling` | `Symbol` | Outcome (e.g. `MERCHANT_WINS`, `BUYER_WINS`) |
+
+---
+
+### DISPUTE / REJECTED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Payment |
+| `dispute_id` | `String` | Dispute |
+
+---
+
+### DISPUTE / ESCALATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_id` | `String` | Payment |
+| `dispute_id` | `String` | Dispute |
+| `amount` | `i128` | Disputed amount |
+
+---
+
+## MERCHANT
+
+### MERCHANT / REGISTERED
+
+Emitted by `register_merchant`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `merchant_id` | `Address` | New merchant address |
+| `business_name` | `String` | Display name |
+
+---
+
+### MERCHANT / UPDATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `merchant_id` | `Address` | Merchant address |
+
+---
+
+### MERCHANT / VERIFIED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `merchant_id` | `Address` | Merchant address |
+
+---
+
+### MERCHANT / SUSPENDED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `merchant_id` | `Address` | Merchant address |
+
+---
+
+### MERCHANT / REINSTATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `merchant_id` | `Address` | Merchant address |
+
+---
+
+## LINK
+
+### LINK / CREATED
+
+Emitted by `create_link`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `link_id` | `String` | Link identifier |
+| `merchant_id` | `Address` | Owner |
+
+---
+
+### LINK / USED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `link_id` | `String` | Link identifier |
+| `payer` | `Address` | Who used the link |
+| `amount` | `i128` | Amount paid |
+| `payment_id` | `String` | Generated payment ID |
+
+---
+
+### LINK / DEACTIVATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `link_id` | `String` | Link identifier |
+
+---
+
+## SUBSCRIPTION
+
+### SUBSCRIPTION / CREATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subscription_id` | `String` | Subscription identifier |
+| `payer` | `Address` | Subscriber |
+| `merchant_id` | `Address` | Merchant |
+| `amount` | `i128` | Per-cycle amount |
+
+---
+
+### SUBSCRIPTION / CANCELLED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subscription_id` | `String` | Subscription identifier |
+| `payer` | `Address` | Subscriber |
+
+---
+
+### SUBSCRIPTION / EXPIRED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subscription_id` | `String` | Subscription identifier |
+| `payer` | `Address` | Subscriber |
+
+---
+
+## STREAM
+
+All stream events include `stream_id` as the first payload field (moved from topic to payload during the #284 normalization).
+
+### STREAM / CREATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Fund source |
+| `receiver` | `Address` | Beneficiary |
+| `deposit` | `i128` | Initial deposit |
+
+---
+
+### STREAM / TOPPED_UP
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Who topped up |
+| `amount` | `i128` | Added amount |
+
+---
+
+### STREAM / WITHDRAWN
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `receiver` | `Address` | Recipient |
+| `destination` | `Address` | Destination wallet |
+| `amount` | `i128` | Amount withdrawn |
+| `remaining` | `i128` | Remaining deposit |
+
+---
+
+### STREAM / CANCELLED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Canceller |
+| `accrued` | `i128` | Amount accrued to receiver |
+| `refund` | `i128` | Amount refunded to sender |
+
+---
+
+### STREAM / PAUSED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Who paused |
+
+---
+
+### STREAM / RESUMED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Who resumed |
+
+---
+
+### STREAM / RATE_UPDATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Who updated |
+| `old_rate` | `i128` | Previous rate per second |
+| `new_rate` | `i128` | New rate per second |
+| `surplus` | `i128` | Refunded surplus deposit |
+
+---
+
+### STREAM / RATE_DECREASED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Who decreased |
+| `old_rate` | `i128` | Previous rate per second |
+| `new_rate` | `i128` | New rate per second |
+| `surplus` | `i128` | Refunded surplus |
+
+---
+
+### STREAM / MILESTONE_APPROVED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Approver |
+
+---
+
+### STREAM / DESTINATION_SET
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `recipient` | `Address` | Receiver |
+| `destination` | `Address` | New destination |
+
+---
+
+### STREAM / CLOSED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stream_id` | `String` | Stream identifier |
+| `sender` | `Address` | Who closed |
+| `receiver` | `Address` | Beneficiary |
+| `residual` | `i128` | Final residual amount returned |
+
+---
+
+## RATE (FX Oracle)
+
+### RATE / UPDATED
+
+Emitted by `update_rate`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pair` | `Symbol` | Trading pair (e.g. `XLMUSDC`) |
+| `rate` | `i128` | New rate (scaled) |
+| `timestamp` | `u64` | Ledger timestamp |
+
+---
+
+## ACCESS_CONTROL
+
+### ACCESS_CONTROL / ROLE_GRANTED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `role` | `Symbol` | Role name |
+| `account` | `Address` | Account granted the role |
+
+---
+
+### ACCESS_CONTROL / ROLE_REVOKED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `role` | `Symbol` | Role name |
+| `account` | `Address` | Account whose role was revoked |
+
+---
+
+## FEE_SPLIT
+
+### FEE_SPLIT / UPDATED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `flat_fee` | `i128` | New flat fee |
+| `bps` | `u32` | New basis-point fee |
+
+---
+
+## TREASURY
+
+### TREASURY / WITHDRAWN
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `admin` | `Address` | Admin who withdrew |
+| `amount` | `i128` | Withdrawn amount |
+
+---
+
+## CONTRACT
+
+### CONTRACT / UPGRADED
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `old_version` | `String` | Previous version string |
+| `new_version` | `String` | New version string |
+
+---
+
+## Topic Format Reference
+
+Every event uses a **2-tuple** topic:
+
+```rust
+env.events().publish(
+    (Symbol::new(&env, "NAMESPACE"), Symbol::new(&env, "ACTION")),
+    payload,
+)
+```
+
+This ensures consistent indexing and filtering by off-chain listeners via the Stellar Horizon API `?topic[]=...` filter parameter.

--- a/fluxapay/src/auth_test.rs
+++ b/fluxapay/src/auth_test.rs
@@ -91,7 +91,7 @@ fn test_renounce_role_non_holder_is_idempotent() {
     let role = Symbol::new(&env, "ORACLE");
 
     let result = refund_client.try_renounce_role(&account, &role);
-    assert_eq!(result, Ok(()));
+    assert!(result.is_ok());
 }
 
 #[test]

--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -1,4 +1,4 @@
-use crate::{
+﻿use crate::{
     Dispute, DisputeStatus, PaymentProcessor, PaymentProcessorClient, Refund, RefundManager,
     RefundManagerClient, RefundStatus,
 };
@@ -45,7 +45,7 @@ fn create_payment_args(
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     }
 }
 

--- a/fluxapay/src/fx_oracle_test.rs
+++ b/fluxapay/src/fx_oracle_test.rs
@@ -106,7 +106,7 @@ fn test_oracle_grant_role_by_admin_grants_role() {
     let oracle = Address::generate(&env);
     let role = Symbol::new(&env, "ORACLE");
 
-    client.oracle_grant_role(&admin, &role, &oracle).unwrap();
+    client.oracle_grant_role(&admin, &role, &oracle);
     assert!(client.oracle_has_role(&role, &oracle));
 }
 

--- a/fluxapay/src/integration_test.rs
+++ b/fluxapay/src/integration_test.rs
@@ -1,4 +1,4 @@
-use crate::{
+﻿use crate::{
     merchant_registry::{KycTier, MerchantRegistry, MerchantRegistryClient},
     DisputeStatus, PaymentProcessor, PaymentProcessorClient, PaymentStatus, RefundManager,
     RefundManagerClient, RefundStatus, SettlementSplit,
@@ -78,7 +78,7 @@ fn test_happy_path_flow() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -149,7 +149,7 @@ fn test_settlement_path() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -202,7 +202,7 @@ fn test_failure_and_expiration_path() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -323,7 +323,7 @@ fn test_upgrade_contract_storage_compatibility() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -369,7 +369,7 @@ fn test_prune_expired_payments_expired_pending() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -414,7 +414,7 @@ fn test_prune_expired_payments_non_expired_skipped() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -458,7 +458,7 @@ fn test_prune_expired_payments_non_pending_skipped() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -551,7 +551,7 @@ fn test_settle_payment_with_zero_merchant_fee() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -614,7 +614,7 @@ fn test_settle_payment_with_bps_only_fee() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -677,7 +677,7 @@ fn test_settle_payment_with_fixed_fee() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -740,7 +740,7 @@ fn test_settle_payment_with_combined_fee() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -789,7 +789,7 @@ fn test_settle_payment_no_registry_configured() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -859,7 +859,7 @@ fn test_cross_contract_happy_path() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
     payment_client.create_payment(&args);
 
@@ -928,7 +928,7 @@ fn test_cross_contract_unverified_merchant_rejection() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
 
     // Creating payment with unverified merchant should fail
@@ -983,7 +983,7 @@ fn test_cross_contract_suspended_merchant_rejection() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
 
     // Creating payment with suspended merchant should fail
@@ -1030,7 +1030,7 @@ fn test_cross_contract_registry_not_set_regression() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
 
     // Should succeed because merchant has MERCHANT role (registry check skipped)

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -2,8 +2,8 @@
 #![allow(clippy::too_many_arguments)]
 use crate::merchant_registry::KycTier;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, vec, Address, BytesN, Env,
-    MuxedAddress, String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, map, token, vec, Address, BytesN, Env,
+    Map, MuxedAddress, String, Symbol, Vec,
 };
 
 pub const PAYMENT_TOLERANCE: i128 = 1;
@@ -102,6 +102,8 @@ pub struct PaymentCharge {
     pub fx_rate: Option<i128>,
     /// Issue #304: Timestamp when the FX rate was captured.
     pub fx_rate_at: Option<u64>,
+    /// Arbitrary key-value metadata supplied by the merchant at creation time (max 20 keys, 256 chars per value).
+    pub metadata: Option<Map<String, String>>,
 }
 
 #[contracttype]
@@ -271,9 +273,9 @@ pub enum Error {
     UpgradeFailed = 48,
     /// Treasury balance is smaller than the requested withdrawal amount.
     InsufficientTreasuryBalance = 46,
-    /// Issue #317: Payment link metadata has too many keys (> 20).
-    MetadataTooLarge = 46,
-    /// Issue #317: Payment link metadata value exceeds maximum length (> 256 chars).
+    /// Metadata map has too many keys (> 20).
+    MetadataTooLarge = 49,
+    /// A metadata value exceeds maximum length (> 256 chars).
     MetadataValueTooLong = 47,
 }
 
@@ -292,6 +294,8 @@ pub struct CreatePaymentArgs {
     pub token_address: Option<Address>,
     pub client_token: Option<String>,
     pub metadata_hash: Option<BytesN<32>>,
+    /// Arbitrary key-value metadata (max 20 keys, 256 chars per value).
+    pub metadata: Option<Map<String, String>>,
 }
 
 #[contracttype]
@@ -972,6 +976,7 @@ impl RefundManager {
                 swap_path: None,
                 fx_rate: None,
                 fx_rate_at: None,
+                metadata: None,
             };
             env.storage()
                 .persistent()
@@ -1954,7 +1959,7 @@ impl RefundManager {
         dispute.escalated = true;
         env.storage()
             .persistent()
-            .set(&DataKey::Dispute(dispute_id.clone()), &dispute);
+            .set(&DataKey::Dispute(dispute_id.clone()), &*dispute);
         Self::bump_dispute_ttl(env, dispute_id, &dispute.status);
         env.events().publish(
             (Symbol::new(env, "DISPUTE"), Symbol::new(env, "ESCALATED")),
@@ -3199,7 +3204,10 @@ impl RefundManager {
 
             // Emit explicit expired event when the subscription reached its cap.
             if subscription.status == SubscriptionStatus::Expired {
-                env.events().publish((Symbol::new(&env, "SUBSCRIPTION_EXPIRED"),), (subscription_id, payer));
+                env.events().publish(
+                    (Symbol::new(&env, "SUBSCRIPTION"), Symbol::new(&env, "EXPIRED")),
+                    (subscription_id, payer),
+                );
             }
         } else {
             // ── Failure path — grace period / retry logic ─────────────────────
@@ -3229,9 +3237,6 @@ impl RefundManager {
                         subscription.retry_count,
                     ),
                 );
-
-                // Also emit a single-topic cancellation event for indexers.
-                env.events().publish((Symbol::new(&env, "SUBSCRIPTION_CANCELLED"),), (subscription_id, payer));
 
                 return Err(Error::SubscriptionRetryExhausted);
             } else {
@@ -3317,8 +3322,10 @@ impl RefundManager {
         // Issue #302: Remove from ActiveSubscriptions index
         Self::remove_active_subscription(&env, &subscription_id);
 
-        // Emit cancellation event for consumers and indexers
-        env.events().publish((Symbol::new(&env, "SUBSCRIPTION_CANCELLED"),), (payer,));
+        env.events().publish(
+            (Symbol::new(&env, "SUBSCRIPTION"), Symbol::new(&env, "CANCELLED")),
+            (subscription_id, payer),
+        );
 
         Ok(())
     }
@@ -3494,6 +3501,7 @@ impl RefundManager {
                 swap_path: None,
                 fx_rate: None,
                 fx_rate_at: None,
+                metadata: None,
             };
 
             env.storage()
@@ -3536,8 +3544,8 @@ impl RefundManager {
                     );
 
                     env.events().publish(
-                        (Symbol::new(&env, "SUBSCRIPTION_CANCELLED"),),
-                        (subscription.payer_address.clone(),),
+                        (Symbol::new(&env, "SUBSCRIPTION"), Symbol::new(&env, "CANCELLED")),
+                        (subscription_id.clone(), subscription.payer_address.clone()),
                     );
                 }
             }
@@ -3550,9 +3558,8 @@ impl RefundManager {
                 (
                     Symbol::new(&env, "PAYMENT"),
                     Symbol::new(&env, "CREATED"),
-                    subscription.merchant_id.clone(),
                 ),
-                (payment_id.clone(), subscription.amount),
+                (payment_id.clone(), subscription.merchant_id.clone(), subscription.amount, None::<Map<String, String>>),
             );
 
             total_payments = total_payments.saturating_add(1);
@@ -4382,6 +4389,18 @@ impl PaymentProcessor {
             return Err(Error::InvalidPaymentId);
         }
 
+        // Issue #286: Validate metadata constraints
+        if let Some(ref meta_map) = args.metadata {
+            if meta_map.len() > 20 {
+                return Err(Error::MetadataTooLarge);
+            }
+            for (_, value) in meta_map.iter() {
+                if value.len() > 256 {
+                    return Err(Error::MetadataValueTooLong);
+                }
+            }
+        }
+
         Self::enforce_create_payment_rate_limit(&env, &args.merchant_id)?;
 
         let now = env.ledger().timestamp();
@@ -4414,6 +4433,7 @@ impl PaymentProcessor {
             swap_path: None,
             fx_rate: None,
             fx_rate_at: None,
+            metadata: args.metadata.clone(),
         };
 
         env.storage()
@@ -4429,15 +4449,13 @@ impl PaymentProcessor {
             .set(&merchant_payments_key, &merchant_payments);
         Self::bump_ttl(&env, &merchant_payments_key, LONG_LIVE_TTL);
 
-        // Issue #166: Optimize event topics for high-volume ingestions
-        // Use standardized (Symbol, Symbol, Address) format for efficient wildcard filtering
+        // Issue #284: Normalised 2-tuple topic; merchant_id and metadata included in payload.
         env.events().publish(
             (
                 Symbol::new(&env, "PAYMENT"),
                 Symbol::new(&env, "CREATED"),
-                args.merchant_id.clone(),
             ),
-            (args.payment_id.clone(), args.amount),
+            (args.payment_id.clone(), args.merchant_id.clone(), args.amount, args.metadata.clone()),
         );
 
         // Persist idempotency key → payment_id mapping so retries are safe.
@@ -4562,6 +4580,18 @@ impl PaymentProcessor {
                 return Err(Error::InvalidPaymentId);
             }
 
+            // Issue #286: Validate metadata constraints
+            if let Some(ref meta_map) = args.metadata {
+                if meta_map.len() > 20 {
+                    return Err(Error::MetadataTooLarge);
+                }
+                for (_, value) in meta_map.iter() {
+                    if value.len() > 256 {
+                        return Err(Error::MetadataValueTooLong);
+                    }
+                }
+            }
+
             // Check idempotency
             if let Some(ref token) = args.client_token {
                 let key = DataKey::IdempotencyKey(token.clone());
@@ -4574,7 +4604,7 @@ impl PaymentProcessor {
         }
 
         for merchant_id in batch_merchants.iter() {
-            Self::enforce_create_payment_batch_rate_limit(&env, merchant_id)?;
+            Self::enforce_create_payment_batch_rate_limit(&env, &merchant_id)?;
         }
 
         // All validations passed, now create all payments
@@ -4611,6 +4641,7 @@ impl PaymentProcessor {
                 swap_path: None,
                 fx_rate: None,
                 fx_rate_at: None,
+                metadata: args.metadata.clone(),
             };
 
             env.storage()
@@ -4626,14 +4657,12 @@ impl PaymentProcessor {
                 .set(&merchant_payments_key, &merchant_payments);
             Self::bump_ttl(&env, &merchant_payments_key, LONG_LIVE_TTL);
 
-            // Issue #166: Optimize event topics
             env.events().publish(
                 (
                     Symbol::new(&env, "PAYMENT"),
                     Symbol::new(&env, "CREATED"),
-                    args.merchant_id.clone(),
                 ),
-                (args.payment_id.clone(), args.amount),
+                (args.payment_id.clone(), args.merchant_id.clone(), args.amount, args.metadata.clone()),
             );
 
             // Persist idempotency key
@@ -5404,6 +5433,7 @@ impl PaymentProcessor {
             token_address: Some(settlement_token),
             client_token: None,
             metadata_hash: None,
+            metadata: None,
         };
 
         let mut payment = Self::create_payment(env.clone(), create_args)?;
@@ -5793,15 +5823,6 @@ impl PaymentProcessor {
         PaymentStreaming::top_up_multiple_streams(env, sender, top_ups)
     }
 
-    pub fn top_up_stream(
-        env: Env,
-        sender: Address,
-        stream_id: String,
-        amount: i128,
-    ) -> Result<(), StreamError> {
-        PaymentStreaming::top_up_stream(env, sender, stream_id, amount)
-    }
-
     /// Update the flow rate of an active stream (increase or decrease).
     pub fn update_stream_rate(
         env: Env,
@@ -5904,10 +5925,7 @@ fn bump_version_string(env: &Env, version: &String) -> String {
     // Bump by 1
     let new_num = num_val.saturating_add(1);
 
-    // Build prefix (everything before the number)
-    let prefix_bytes = &bytes.to_array::<32>().unwrap_or([0u8; 32])[..num_start];
-
-    // Encode the new number as an ASCII byte slice
+    // Encode the new number as ASCII digits
     let mut num_buf = [0u8; 12];
     let mut num_len = 0usize;
     if new_num == 0 {
@@ -5929,34 +5947,32 @@ fn bump_version_string(env: &Env, version: &String) -> String {
         }
     }
 
-    // Build suffix (everything after the number)
-    let suffix_start = j;
-    let mut suffix = version.to_bytes();
-    let suffix_part: Bytes = {
-        let mut b = Bytes::new(env);
-        let mut k = suffix_start;
-        while k < len {
-            b.push_back(bytes.get(k as u32).unwrap_or(b' '));
-            k += 1;
-        }
-        b
-    };
-
-    // Reconstruct: prefix + new_number + suffix
-    let mut result = Bytes::new(env);
-    for &b in prefix_bytes.iter().take(num_start) {
-        result.push_back(b);
+    // Reconstruct into a fixed-size buffer (max 64 bytes handles any sane version string)
+    let mut result = [0u8; 64];
+    let mut pos = 0usize;
+    // prefix: bytes before the number
+    let mut p = 0usize;
+    while p < num_start && pos < 64 {
+        result[pos] = bytes.get(p as u32).unwrap_or(b' ');
+        pos += 1;
+        p += 1;
     }
+    // new number digits
     for k in 0..num_len {
-        result.push_back(num_buf[k]);
+        if pos < 64 {
+            result[pos] = num_buf[k];
+            pos += 1;
+        }
     }
-    let mut k = 0usize;
-    while k < suffix_part.len() as usize {
-        result.push_back(suffix_part.get(k as u32).unwrap_or(b' '));
+    // suffix: bytes after the number
+    let mut k = j;
+    while k < len && pos < 64 {
+        result[pos] = bytes.get(k as u32).unwrap_or(b' ');
+        pos += 1;
         k += 1;
     }
 
-    String::from_bytes(env, &result)
+    String::from_bytes(env, &result[..pos])
 }
 
 #[cfg(test)]
@@ -5985,6 +6001,8 @@ mod pause_test;
 #[cfg(test)]
 mod payment_link_test;
 mod test;
+#[cfg(test)]
+mod payment_metadata_test;
 
 // Payment streaming module (Issue #127)
 pub mod stream;

--- a/fluxapay/src/memo_test.rs
+++ b/fluxapay/src/memo_test.rs
@@ -1,4 +1,4 @@
-use crate::{
+﻿use crate::{
     access_control::role_merchant, CreatePaymentArgs, PaymentProcessor, PaymentProcessorClient,
     PaymentStatus,
 };
@@ -32,7 +32,7 @@ fn create_payment_args(
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     }
 }
 

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -1,4 +1,4 @@
-use super::merchant_registry::*;
+﻿use super::merchant_registry::*;
 use crate::{PaymentProcessor, PaymentProcessorClient, RefundManager, RefundManagerClient};
 use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String, Symbol};
 
@@ -360,7 +360,7 @@ fn test_unverified_merchant_cannot_create_payment() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
 
     // This should panic with Unauthorized error
@@ -421,7 +421,7 @@ fn test_verified_merchant_can_create_payment() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
 
     let payment = payment_client.create_payment(&args);
@@ -1118,6 +1118,9 @@ fn test_get_all_merchants_pagination_offset_one() {
     let page_out_of_range = client.get_all_merchants(&6, &3);
     assert_eq!(page_out_of_range.len(), 0);
 }
+
+#[test]
+fn test_get_all_merchants_zero_limit() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -1329,7 +1332,7 @@ fn test_basic_tier_cap_enforced() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     });
     payment_client.verify_payment(
         &oracle,
@@ -1353,7 +1356,7 @@ fn test_basic_tier_cap_enforced() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     });
 
     let result = payment_client.try_verify_payment(
@@ -1394,7 +1397,7 @@ fn test_business_tier_no_cap() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     });
     payment_client.verify_payment(
         &oracle,
@@ -1433,7 +1436,7 @@ fn test_volume_resets_next_month() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     });
     payment_client.verify_payment(
         &oracle,
@@ -1460,7 +1463,7 @@ fn test_volume_resets_next_month() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     });
     payment_client.verify_payment(
         &oracle,

--- a/fluxapay/src/pause_test.rs
+++ b/fluxapay/src/pause_test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+﻿#![cfg(test)]
 
 use crate::{CreatePaymentArgs, PaymentProcessorClient};
 use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
@@ -60,7 +60,7 @@ fn test_global_pause_blocks_creation() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     });
 
     assert!(res.is_err());
@@ -105,7 +105,7 @@ fn test_creation_pause_blocks_only_creation() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     });
     assert!(res.is_err());
 

--- a/fluxapay/src/payment_link_test.rs
+++ b/fluxapay/src/payment_link_test.rs
@@ -1,7 +1,7 @@
-use crate::{PaymentLinkManager, PaymentLinkManagerClient};
+﻿use crate::{PaymentLinkManager, PaymentLinkManagerClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
-    token, Address, Env, Map, String, Symbol,
+    token, vec, Address, Env, Map, String, Symbol,
 };
 
 fn setup_payment_link(env: &Env) -> (Address, PaymentLinkManagerClient<'_>) {
@@ -61,7 +61,7 @@ fn test_use_link_fixed_amount() {
         &None,
         &false,
         &None,
-    ).unwrap();
+    );
 
     let payment_id = client.use_link(&payer, &link_id, &amount, &None);
     assert!(!payment_id.is_empty());
@@ -112,9 +112,9 @@ fn test_use_link_open_amount() {
         &None,
         &false,
         &None,
-    ).unwrap();
+    );
 
-    client.use_link(&payer, &link_id, &1500i128, &None).unwrap();
+    client.use_link(&payer, &link_id, &1500i128, &None);
     let link = client.get_link(&link_id);
     assert_eq!(link.use_count, 1);
 }
@@ -136,7 +136,7 @@ fn test_deactivate_link() {
         &None,
         &false,
         &None,
-    ).unwrap();
+    );
 
     client.deactivate_link(&merchant, &link_id);
     let link = client.get_link(&link_id);
@@ -163,10 +163,10 @@ fn test_link_expired() {
         &None,
         &false,
         &None,
-    ).unwrap();
+    );
 
     env.ledger().set_timestamp(expiry + 1);
-    client.use_link(&payer, &link_id, &100i128, &None).unwrap();
+    client.use_link(&payer, &link_id, &100i128, &None);
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn test_verify_batch_returns_status_for_active_links() {
         &None,
         &false,
         &None,
-    ).unwrap();
+    );
     client.create_link(
         &merchant,
         &link_id2,
@@ -199,12 +199,12 @@ fn test_verify_batch_returns_status_for_active_links() {
         &None,
         &false,
         &None,
-    ).unwrap();
+    );
 
     let results = client.verify_batch(&vec![&env, link_id1.clone(), link_id2.clone()]);
     assert_eq!(results.len(), 2);
-    assert_eq!(results[0], (link_id1.clone(), true, 0, None));
-    assert_eq!(results[1], (link_id2.clone(), true, 0, None));
+    assert_eq!(results.get(0).unwrap(), (link_id1.clone(), true, 0, None));
+    assert_eq!(results.get(1).unwrap(), (link_id2.clone(), true, 0, None));
 }
 
 #[test]
@@ -226,12 +226,12 @@ fn test_verify_batch_handles_missing_links() {
         &None,
         &false,
         &None,
-    ).unwrap();
+    );
 
     let results = client.verify_batch(&vec![&env, existing_link.clone(), missing_link.clone()]);
     assert_eq!(results.len(), 2);
-    assert_eq!(results[0], (existing_link.clone(), true, 0, None));
-    assert_eq!(results[1], (missing_link.clone(), false, 0, None));
+    assert_eq!(results.get(0).unwrap(), (existing_link.clone(), true, 0, None));
+    assert_eq!(results.get(1).unwrap(), (missing_link.clone(), false, 0, None));
 }
 
 #[test]
@@ -251,13 +251,13 @@ fn test_verify_batch_returns_inactive_for_deactivated_link() {
         &Some(10),
         &false,
         &None,
-    ).unwrap();
+    );
 
     client.deactivate_link(&merchant, &link_id);
 
     let results = client.verify_batch(&vec![&env, link_id.clone()]);
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0], (link_id.clone(), false, 0, Some(10)));
+    assert_eq!(results.get(0).unwrap(), (link_id.clone(), false, 0, Some(10)));
 }
 
 #[test]
@@ -266,7 +266,7 @@ fn test_verify_batch_empty_input_returns_empty_vec() {
     env.mock_all_auths();
     let (_merchant, client) = setup_payment_link(&env);
 
-    let results: Vec<(String, bool, u32, Option<u32>)> = client.verify_batch(&vec![&env]);
+    let results = client.verify_batch(&soroban_sdk::vec![&env]);
     assert!(results.is_empty());
 }
 
@@ -289,11 +289,11 @@ fn test_max_uses() {
         &Some(1),
         &false,
         &None,
-    ).unwrap();
+    );
 
-    client.use_link(&payer, &link_id, &100i128, &None).unwrap();
+    client.use_link(&payer, &link_id, &100i128, &None);
     // Should fail on second use
-    client.use_link(&payer, &link_id, &100i128, &None).unwrap();
+    client.use_link(&payer, &link_id, &100i128, &None);
 }
 
 // ── Issue #111: Direct-to-Merchant Payment Flow ──────────────────────────────
@@ -327,7 +327,7 @@ fn test_direct_transfer_link_transfers_to_merchant() {
         &None,
         &true,
         &None, // direct_transfer = true
-    ).unwrap();
+    );
 
     let link = client.get_link(&link_id);
     assert!(link.direct_transfer);
@@ -335,7 +335,7 @@ fn test_direct_transfer_link_transfers_to_merchant() {
     let token_client = token::TokenClient::new(&env, &usdc_token);
     let merchant_balance_before = token_client.balance(&merchant);
 
-    client.use_link(&payer, &link_id, &amount, &Some(usdc_token.clone())).unwrap();
+    client.use_link(&payer, &link_id, &amount, &Some(usdc_token.clone()));
 
     let merchant_balance_after = token_client.balance(&merchant);
     assert_eq!(merchant_balance_after - merchant_balance_before, amount);
@@ -361,27 +361,29 @@ fn test_direct_transfer_without_token_address_fails() {
         &None,
         &true,
         &None,
-    ).unwrap();
+    );
 
     // Should fail because usdc_token is None but direct_transfer is true
-    client.use_link(&payer, &link_id, &500i128, &None).unwrap();
+    client.use_link(&payer, &link_id, &500i128, &None);
 }
 
 // ── Issue #317: Payment Link Metadata Validation ────────────────────────────
 
 #[test]
-#[should_panic(expected = "Error(Contract, #46)")]
+#[should_panic(expected = "Error(Contract, #49)")]
 fn test_metadata_too_large_21_keys() {
     let env = Env::default();
     env.mock_all_auths();
     let (merchant, client) = setup_payment_link(&env);
 
     let link_id = String::from_str(&env, "meta_large");
+    let keys_21 = [
+        "k0","k1","k2","k3","k4","k5","k6","k7","k8","k9",
+        "k10","k11","k12","k13","k14","k15","k16","k17","k18","k19","k20",
+    ];
     let mut metadata = Map::new(&env);
-    for i in 0..21 {
-        let key = String::from_str(&env, &format!("key_{}", i));
-        let value = String::from_str(&env, "value");
-        metadata.set(key, value);
+    for k in keys_21.iter() {
+        metadata.set(String::from_str(&env, k), String::from_str(&env, "v"));
     }
 
     client.create_link(
@@ -394,7 +396,7 @@ fn test_metadata_too_large_21_keys() {
         &None,
         &false,
         &Some(metadata),
-    ).unwrap();
+    );
 }
 
 #[test]
@@ -406,7 +408,7 @@ fn test_metadata_value_too_long_257_chars() {
 
     let link_id = String::from_str(&env, "meta_long");
     let mut metadata = Map::new(&env);
-    let long_value = String::from_str(&env, &"x".repeat(257));
+    let long_value = String::from_str(&env, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     metadata.set(String::from_str(&env, "key"), long_value);
 
     client.create_link(
@@ -419,7 +421,7 @@ fn test_metadata_value_too_long_257_chars() {
         &None,
         &false,
         &Some(metadata),
-    ).unwrap();
+    );
 }
 
 #[test]
@@ -430,10 +432,13 @@ fn test_metadata_20_keys_256_char_values_succeeds() {
 
     let link_id = String::from_str(&env, "meta_valid");
     let mut metadata = Map::new(&env);
-    for i in 0..20 {
-        let key = String::from_str(&env, &format!("key_{}", i));
-        let value = String::from_str(&env, &"x".repeat(256));
-        metadata.set(key, value);
+    let keys_20 = [
+        "k0","k1","k2","k3","k4","k5","k6","k7","k8","k9",
+        "k10","k11","k12","k13","k14","k15","k16","k17","k18","k19",
+    ];
+    let val256 = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    for k in keys_20.iter() {
+        metadata.set(String::from_str(&env, k), String::from_str(&env, val256));
     }
 
     let id = client.create_link(
@@ -446,7 +451,7 @@ fn test_metadata_20_keys_256_char_values_succeeds() {
         &None,
         &false,
         &Some(metadata),
-    ).unwrap();
+    );
 
     assert_eq!(id, link_id);
     let link = client.get_link(&link_id);
@@ -470,7 +475,7 @@ fn test_metadata_none_succeeds() {
         &None,
         &false,
         &None,
-    ).unwrap();
+    );
 
     assert_eq!(id, link_id);
     let link = client.get_link(&link_id);

--- a/fluxapay/src/payment_metadata_test.rs
+++ b/fluxapay/src/payment_metadata_test.rs
@@ -1,0 +1,195 @@
+#![cfg(test)]
+
+use crate::{access_control::role_merchant, CreatePaymentArgs, PaymentProcessor, PaymentProcessorClient};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events as _, Address, Env, Map, String, Symbol,
+};
+
+fn setup(env: &Env) -> (Address, Address, PaymentProcessorClient<'_>) {
+    let contract_id = env.register(PaymentProcessor, ());
+    let client = PaymentProcessorClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize_payment_processor(&admin);
+    let merchant = Address::generate(env);
+    client.grant_role(&admin, &role_merchant(env), &merchant);
+    (admin, merchant, client)
+}
+
+fn payment_args(
+    env: &Env,
+    merchant: &Address,
+    metadata: Option<Map<String, String>>,
+) -> CreatePaymentArgs {
+    CreatePaymentArgs {
+        payment_id: String::from_str(env, "pay_meta_01"),
+        merchant_id: merchant.clone(),
+        amount: 1_000_000_000i128,
+        currency: Symbol::new(env, "USDC"),
+        deposit_address: Address::generate(env),
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+        metadata,
+    }
+}
+
+// ─── Issue #286: PaymentCharge metadata field ────────────────────────────────
+
+#[test]
+fn test_create_payment_nil_metadata() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, merchant, client) = setup(&env);
+
+    let payment = client.create_payment(&payment_args(&env, &merchant, None));
+    assert!(payment.metadata.is_none());
+
+    let retrieved = client.get_payment(&payment.payment_id);
+    assert!(retrieved.metadata.is_none());
+}
+
+#[test]
+fn test_create_payment_with_valid_metadata() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, merchant, client) = setup(&env);
+
+    let mut meta: Map<String, String> = Map::new(&env);
+    meta.set(
+        String::from_str(&env, "order_id"),
+        String::from_str(&env, "ORD-9999"),
+    );
+    meta.set(
+        String::from_str(&env, "customer_ref"),
+        String::from_str(&env, "CUST-42"),
+    );
+
+    let payment = client.create_payment(&payment_args(&env, &merchant, Some(meta.clone())));
+    assert!(payment.metadata.is_some());
+
+    let retrieved = client.get_payment(&payment.payment_id);
+    let stored_meta = retrieved.metadata.unwrap();
+    assert_eq!(
+        stored_meta.get(String::from_str(&env, "order_id")),
+        Some(String::from_str(&env, "ORD-9999"))
+    );
+    assert_eq!(
+        stored_meta.get(String::from_str(&env, "customer_ref")),
+        Some(String::from_str(&env, "CUST-42"))
+    );
+}
+
+#[test]
+fn test_create_payment_metadata_at_max_keys() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, merchant, client) = setup(&env);
+
+    let keys = [
+        "k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8", "k9",
+        "k10", "k11", "k12", "k13", "k14", "k15", "k16", "k17", "k18", "k19",
+    ];
+    let mut meta: Map<String, String> = Map::new(&env);
+    for k in keys.iter() {
+        meta.set(String::from_str(&env, k), String::from_str(&env, "v"));
+    }
+
+    // Exactly 20 keys should succeed.
+    let payment = client.create_payment(&payment_args(&env, &merchant, Some(meta)));
+    assert!(payment.metadata.is_some());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #49)")]
+fn test_create_payment_metadata_too_many_keys() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, merchant, client) = setup(&env);
+
+    let keys = [
+        "k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8", "k9",
+        "k10", "k11", "k12", "k13", "k14", "k15", "k16", "k17", "k18", "k19", "k20",
+    ];
+    let mut meta: Map<String, String> = Map::new(&env);
+    for k in keys.iter() {
+        meta.set(String::from_str(&env, k), String::from_str(&env, "v"));
+    }
+
+    client.create_payment(&payment_args(&env, &merchant, Some(meta)));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #47)")]
+fn test_create_payment_metadata_value_too_long() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, merchant, client) = setup(&env);
+
+    // 257 'x' characters — one over the 256-char limit
+    let long_value = String::from_str(
+        &env,
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    );
+
+    let mut meta: Map<String, String> = Map::new(&env);
+    meta.set(String::from_str(&env, "key"), long_value);
+
+    client.create_payment(&payment_args(&env, &merchant, Some(meta)));
+}
+
+#[test]
+fn test_create_payment_metadata_in_event_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, merchant, client) = setup(&env);
+
+    let mut meta: Map<String, String> = Map::new(&env);
+    meta.set(
+        String::from_str(&env, "sku"),
+        String::from_str(&env, "SKU-001"),
+    );
+
+    let payment = client.create_payment(&payment_args(&env, &merchant, Some(meta.clone())));
+
+    // Verify the PAYMENT/CREATED event uses a 2-tuple topic.
+    let events = env.events().all();
+    let mut found = false;
+    for event in events.iter() {
+        let (_, topics, _) = event;
+        // topics is a Vec; expect exactly 2 elements: ("PAYMENT", "CREATED")
+        if topics.len() == 2 {
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "PAYMENT/CREATED event should have a 2-tuple topic");
+    assert!(payment.metadata.is_some());
+}
+
+// ─── Issue #284: 2-tuple topics ──────────────────────────────────────────────
+
+#[test]
+fn test_payment_created_event_is_two_tuple() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, merchant, client) = setup(&env);
+
+    client.create_payment(&payment_args(&env, &merchant, None));
+
+    let events = env.events().all();
+    // Find the PAYMENT/CREATED event and confirm the topic is a 2-tuple.
+    let mut payment_created_found = false;
+    for event in events.iter() {
+        let (_, topics, _data) = event;
+        if topics.len() == 2 {
+            payment_created_found = true;
+        }
+        // No 3-tuple topics should exist in our new events.
+        assert!(topics.len() <= 2, "All events must use at most a 2-tuple topic; got {} elements", topics.len());
+    }
+    assert!(payment_created_found, "Expected at least one 2-tuple event");
+}

--- a/fluxapay/src/proptests.rs
+++ b/fluxapay/src/proptests.rs
@@ -1,4 +1,4 @@
-use crate::format_id;
+﻿use crate::format_id;
 use proptest::prelude::*;
 use soroban_sdk::{
     testutils::{Address as _, BytesN as _, Ledger as _},
@@ -93,7 +93,7 @@ proptest! {
             memo_type: None,
             token_address: None,
             client_token: None,
-            metadata_hash: None,
+            metadata_hash: None, metadata: None,
         };
 
         client.create_payment(&args);
@@ -143,7 +143,7 @@ proptest! {
             memo_type: None,
             token_address: None,
             client_token: None,
-            metadata_hash: None,
+            metadata_hash: None, metadata: None,
         };
 
         client.create_payment(&args);

--- a/fluxapay/src/stream.rs
+++ b/fluxapay/src/stream.rs
@@ -302,12 +302,8 @@ impl PaymentStreaming {
         token_client.transfer(&stream.sender, env.current_contract_address(), &deposit);
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "CREATED"),
-                stream_id.clone(),
-            ),
-            (stream.sender.clone(), stream.receiver.clone(), deposit),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "CREATED")),
+            (stream_id.clone(), stream.sender.clone(), stream.receiver.clone(), deposit),
         );
 
         Ok(stream)
@@ -349,12 +345,8 @@ impl PaymentStreaming {
             .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "DESTINATION_SET"),
-                stream_id,
-            ),
-            (recipient, destination),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "DESTINATION_SET")),
+            (stream_id, recipient, destination),
         );
 
         Ok(())
@@ -384,12 +376,8 @@ impl PaymentStreaming {
             .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "MILESTONE_APPROVED"),
-                stream_id,
-            ),
-            (sender,),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "MILESTONE_APPROVED")),
+            (stream_id, sender),
         );
 
         Ok(())
@@ -505,12 +493,8 @@ impl PaymentStreaming {
 
         // ── Step 3: Emit RateDecreased event ─────────────────────────────────
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "RATE_DECREASED"),
-                stream_id,
-            ),
-            (sender, old_rate, new_rate, surplus),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "RATE_DECREASED")),
+            (stream_id, sender, old_rate, new_rate, surplus),
         );
 
         Ok(())
@@ -659,12 +643,8 @@ impl PaymentStreaming {
                 release_lock(&env, &stream_id);
 
                 env.events().publish(
-                    (
-                        Symbol::new(&env, "STREAM"),
-                        Symbol::new(&env, "WITHDRAWN"),
-                        stream_id.clone(),
-                    ),
-                    (recipient.clone(), recipient.clone(), withdrawable, stream.remaining_deposit),
+                    (Symbol::new(&env, "STREAM"), Symbol::new(&env, "WITHDRAWN")),
+                    (stream_id.clone(), recipient.clone(), recipient.clone(), withdrawable, stream.remaining_deposit),
                 );
 
                 processed.push_back(stream_id);
@@ -747,70 +727,11 @@ impl PaymentStreaming {
         release_lock(&env, &stream_id);
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "WITHDRAWN"),
-                stream_id.clone(),
-            ),
-            (stream.receiver.clone(), destination.clone(), withdrawable, stream.remaining_deposit),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "WITHDRAWN")),
+            (stream_id.clone(), stream.receiver.clone(), destination.clone(), withdrawable, stream.remaining_deposit),
         );
 
         Ok(stream_id)
-    }
-
-    /// Top up an existing payment stream with additional tokens.
-    ///
-    /// Any user may call this to add funds to an active stream. The caller
-    /// transfers `amount` tokens from their account into the contract.
-    ///
-    /// # Parameters
-    /// * `caller` – Account providing the tokens; must sign.
-    /// * `stream_id` – Stream to top up.
-    /// * `amount`    – Amount of tokens to add (must be positive).
-    pub fn top_up_stream(
-        env: Env,
-        caller: Address,
-        stream_id: String,
-        amount: i128,
-    ) -> Result<(), StreamError> {
-        caller.require_auth();
-
-        if amount <= 0 {
-            return Err(StreamError::InvalidDeposit);
-        }
-
-        let mut stream: PaymentStream = env
-            .storage()
-            .persistent()
-            .get(&StreamDataKey::Stream(stream_id.clone()))
-            .ok_or(StreamError::StreamNotFound)?;
-
-        if stream.status != StreamStatus::Active {
-            return Err(StreamError::StreamNotActive);
-        }
-
-        // Effects
-        stream.remaining_deposit = stream.remaining_deposit.saturating_add(amount);
-
-        // Persist state before interaction (CEI pattern)
-        env.storage()
-            .persistent()
-            .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
-
-        // Interaction
-        let token_client = token::Client::new(&env, &stream.token);
-        token_client.transfer(&caller, env.current_contract_address(), &amount);
-
-        env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "TOPPED_UP"),
-                stream_id,
-            ),
-            (caller, amount),
-        );
-
-        Ok(())
     }
 
     /// Top up multiple streams in a single atomic transaction.
@@ -829,7 +750,7 @@ impl PaymentStreaming {
 
         for top_up in top_ups.iter() {
             let (stream_id, amount) = top_up;
-            Self::top_up_stream_internal(&env, &sender, stream_id, *amount)?;
+            Self::top_up_stream_internal(&env, &sender, &stream_id, amount)?;
         }
 
         Ok(())
@@ -879,12 +800,8 @@ impl PaymentStreaming {
         token_client.transfer(sender, env.current_contract_address(), &amount);
 
         env.events().publish(
-            (
-                Symbol::new(env, "STREAM"),
-                Symbol::new(env, "TOPPED_UP"),
-                stream_id.clone(),
-            ),
-            (sender.clone(), amount),
+            (Symbol::new(env, "STREAM"), Symbol::new(env, "TOPPED_UP")),
+            (stream_id.clone(), sender.clone(), amount),
         );
 
         Ok(())
@@ -946,12 +863,8 @@ impl PaymentStreaming {
         }
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "CANCELLED"),
-                stream_id,
-            ),
-            (sender, accrued, refund),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "CANCELLED")),
+            (stream_id, sender, accrued, refund),
         );
 
         Ok(())
@@ -998,12 +911,8 @@ impl PaymentStreaming {
             .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "PAUSED"),
-                stream_id,
-            ),
-            (sender,),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "PAUSED")),
+            (stream_id, sender),
         );
 
         Ok(())
@@ -1041,12 +950,8 @@ impl PaymentStreaming {
             .set(&StreamDataKey::Stream(stream_id.clone()), &stream);
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "RESUMED"),
-                stream_id,
-            ),
-            (sender,),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "RESUMED")),
+            (stream_id, sender),
         );
 
         Ok(())
@@ -1111,12 +1016,8 @@ impl PaymentStreaming {
             }
 
             env.events().publish(
-                (
-                    Symbol::new(&env, "STREAM"),
-                    Symbol::new(&env, "CANCELLED"),
-                    stream_id.clone(),
-                ),
-                (sender.clone(), accrued, refund),
+                (Symbol::new(&env, "STREAM"), Symbol::new(&env, "CANCELLED")),
+                (stream_id.clone(), sender.clone(), accrued, refund),
             );
 
             cancelled.push_back(stream_id);
@@ -1208,12 +1109,8 @@ impl PaymentStreaming {
         }
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "RATE_UPDATED"),
-                stream_id,
-            ),
-            (sender, old_rate, new_rate, surplus),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "RATE_UPDATED")),
+            (stream_id, sender, old_rate, new_rate, surplus),
         );
 
         Ok(())
@@ -1257,12 +1154,8 @@ impl PaymentStreaming {
             .remove(&StreamDataKey::Stream(stream_id.clone()));
 
         env.events().publish(
-            (
-                Symbol::new(&env, "STREAM"),
-                Symbol::new(&env, "CLOSED"),
-                stream_id,
-            ),
-            (stream.sender, stream.receiver, residual),
+            (Symbol::new(&env, "STREAM"), Symbol::new(&env, "CLOSED")),
+            (stream_id, stream.sender, stream.receiver, residual),
         );
 
         Ok(())
@@ -1325,12 +1218,8 @@ impl PaymentStreaming {
             }
 
             env.events().publish(
-                (
-                    Symbol::new(&env, "STREAM"),
-                    Symbol::new(&env, "CANCELLED"),
-                    stream_id.clone(),
-                ),
-                (sender.clone(), accrued, refund),
+                (Symbol::new(&env, "STREAM"), Symbol::new(&env, "CANCELLED")),
+                (stream_id.clone(), sender.clone(), accrued, refund),
             );
 
             cancelled.push_back(stream_id);
@@ -1421,12 +1310,8 @@ impl PaymentStreaming {
             );
 
             env.events().publish(
-                (
-                    Symbol::new(&env, "STREAM"),
-                    Symbol::new(&env, "WITHDRAWN"),
-                    w.stream_id.clone(),
-                ),
-                (recipient.clone(), w.destination.clone(), withdrawable, stream.remaining_deposit),
+                (Symbol::new(&env, "STREAM"), Symbol::new(&env, "WITHDRAWN")),
+                (w.stream_id.clone(), recipient.clone(), w.destination.clone(), withdrawable, stream.remaining_deposit),
             );
 
             processed.push_back(w.stream_id.clone());

--- a/fluxapay/src/stream_test.rs
+++ b/fluxapay/src/stream_test.rs
@@ -1,10 +1,10 @@
-#![cfg(test)]
+﻿#![cfg(test)]
 
 use super::stream::{PaymentStreaming, PaymentStreamingClient, StreamError, StreamStatus};
 use crate::utils::format_id;
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
-    token, Address, Env, String,
+    token, vec, Address, Env, String,
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -331,7 +331,7 @@ fn test_top_up_stream_success() {
     let token_client = token::StellarAssetClient::new(&env, &token);
 
     let stream_id = String::from_str(&env, "stream_top_up");
-    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id);
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id, &None::<i128>);
 
     client.top_up_stream(&sender, &stream_id, &250i128);
 
@@ -348,11 +348,11 @@ fn test_top_up_multiple_streams_success() {
 
     let stream_id1 = String::from_str(&env, "stream_top_up_multi_1");
     let stream_id2 = String::from_str(&env, "stream_top_up_multi_2");
-    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id1);
-    client.create_stream(&sender, &receiver, &token, &20i128, &500i128, &stream_id2);
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id1, &None::<i128>);
+    client.create_stream(&sender, &receiver, &token, &20i128, &500i128, &stream_id2, &None::<i128>);
 
     let top_ups = vec![&env, (stream_id1.clone(), 100i128), (stream_id2.clone(), 200i128)];
-    client.top_up_multiple_streams(&sender, &top_ups).unwrap();
+    client.top_up_multiple_streams(&sender, &top_ups);
 
     let stream1 = client.get_stream(&stream_id1);
     let stream2 = client.get_stream(&stream_id2);
@@ -367,7 +367,7 @@ fn test_top_up_multiple_streams_unauthorized() {
     let (client, sender, receiver, token) = setup(&env);
 
     let stream_id1 = String::from_str(&env, "stream_top_up_multi_auth_1");
-    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id1);
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id1, &None::<i128>);
 
     let impostor = Address::generate(&env);
     let top_ups = vec![&env, (stream_id1.clone(), 100i128)];
@@ -382,7 +382,7 @@ fn test_top_up_stream_unauthorized_caller() {
     let (client, sender, receiver, token) = setup(&env);
 
     let stream_id = String::from_str(&env, "stream_top_up_auth");
-    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id);
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id, &None::<i128>);
 
     let impostor = Address::generate(&env);
     let result = client.try_top_up_stream(&impostor, &stream_id, &50i128);
@@ -396,7 +396,7 @@ fn test_top_up_stream_rejects_inactive_stream() {
     let (client, sender, receiver, token) = setup(&env);
 
     let stream_id = String::from_str(&env, "stream_top_up_inactive");
-    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id);
+    client.create_stream(&sender, &receiver, &token, &10i128, &500i128, &stream_id, &None::<i128>);
     client.cancel_stream(&sender, &stream_id);
 
     let result = client.try_top_up_stream(&sender, &stream_id, &50i128);
@@ -460,7 +460,7 @@ fn test_cancel_multiple_streams_with_partial_invalid_id_errors() {
     let (client, sender, recipient, token) = setup(&env);
 
     let stream_id1 = String::from_str(&env, "stream_cancel_partial_1");
-    client.create_stream(&sender, &recipient, &token, &100i128, &500i128, &stream_id1);
+    client.create_stream(&sender, &recipient, &token, &100i128, &500i128, &stream_id1, &None::<i128>);
 
     let missing_stream_id = String::from_str(&env, "stream_cancel_missing");
     let stream_ids = vec![&env, stream_id1.clone(), missing_stream_id];
@@ -485,8 +485,8 @@ fn test_batch_withdraw_to_multiple_destinations() {
     let destination2 = Address::generate(&env);
 
     token_client.mint(&sender, &10_000i128);
-    client.create_stream(&sender, &recipient, &token, &100i128, &1_000i128, &stream_id1);
-    client.create_stream(&sender, &recipient, &token, &200i128, &2_000i128, &stream_id2);
+    client.create_stream(&sender, &recipient, &token, &100i128, &1_000i128, &stream_id1, &None::<i128>);
+    client.create_stream(&sender, &recipient, &token, &200i128, &2_000i128, &stream_id2, &None::<i128>);
 
     client.approve_stream_milestone(&sender, &stream_id1);
     client.approve_stream_milestone(&sender, &stream_id2);
@@ -504,7 +504,7 @@ fn test_batch_withdraw_to_multiple_destinations() {
     };
     let withdrawals = vec![&env, withdrawal1, withdrawal2];
 
-    let processed = client.batch_withdraw_to(&recipient, &withdrawals).unwrap();
+    let processed = client.batch_withdraw_to(&recipient, &withdrawals);
     assert_eq!(processed.len(), 2);
     assert_eq!(token_client.balance(&destination1), 100);
     assert_eq!(token_client.balance(&destination2), 100);
@@ -521,7 +521,7 @@ fn test_batch_withdraw_to_skips_zero_accrued_streams() {
     let destination = Address::generate(&env);
 
     token_client.mint(&sender, &10_000i128);
-    client.create_stream(&sender, &recipient, &token, &100i128, &1_000i128, &stream_id);
+    client.create_stream(&sender, &recipient, &token, &100i128, &1_000i128, &stream_id, &None::<i128>);
     client.approve_stream_milestone(&sender, &stream_id);
 
     let withdrawal = crate::WithdrawalRecipient {
@@ -531,7 +531,7 @@ fn test_batch_withdraw_to_skips_zero_accrued_streams() {
     };
     let withdrawals = vec![&env, withdrawal];
 
-    let processed = client.batch_withdraw_to(&recipient, &withdrawals).unwrap();
+    let processed = client.batch_withdraw_to(&recipient, &withdrawals);
     assert_eq!(processed.len(), 0);
     assert_eq!(token_client.balance(&destination), 0);
 }

--- a/fluxapay/src/swap_test.rs
+++ b/fluxapay/src/swap_test.rs
@@ -3,7 +3,7 @@ use crate::{
     PaymentProcessor, PaymentProcessorClient, SwapAndPayArgs,
 };
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracterror, testutils::Address as _, vec, Address,
+    contract, contractimpl, contracterror, testutils::Address as _, vec, Address,
     Env, String, Symbol, Vec,
 };
 
@@ -17,18 +17,6 @@ pub enum MockDexError {
 
 #[contract]
 pub struct MockDexRouter;
-
-#[contractclient(name = "MockDexRouterClient")]
-pub trait MockDexRouterTrait {
-    fn swap_exact_tokens_for_tokens(
-        env: Env,
-        amount_in: i128,
-        amount_out_min: i128,
-        path: Vec<Address>,
-        to: Address,
-        deadline: u64,
-    ) -> Result<Vec<i128>, MockDexError>;
-}
 
 #[cfg_attr(
     any(not(target_arch = "wasm32"), feature = "contract-payment-processor"),
@@ -151,7 +139,7 @@ fn test_swap_and_pay_happy_path_with_mock_dex() {
 
     let payment = payment_client.swap_and_pay(&args);
     assert_eq!(payment.payment_id, args.payment_id);
-    assert_eq!(payment.status, Symbol::new(&env, "SETTLED"));
+    assert_eq!(payment.status, crate::PaymentStatus::Settled);
 }
 
 #[test]

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+﻿#![cfg(test)]
 
 use super::*;
 use access_control::{role_admin, role_oracle, role_settlement_operator};
@@ -87,7 +87,7 @@ fn create_payment_args(
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     }
 }
 
@@ -1152,20 +1152,6 @@ fn test_admin_in_role_members_after_init() {
     assert_eq!(members.get(0), Some(admin));
 }
 
-fn setup_refund_manager_with_token(env: &Env) -> (Address, RefundManagerClient<'_>, Address) {
-    let contract_id = env.register(RefundManager, ());
-    let client = RefundManagerClient::new(env, &contract_id);
-    let admin = Address::generate(env);
-    let token_admin = Address::generate(env);
-    let usdc_token = env
-        .register_stellar_asset_contract_v2(token_admin)
-        .address();
-    client.initialize_refund_manager(&admin, &usdc_token);
-    let token_admin_client = token::StellarAssetClient::new(env, &usdc_token);
-    token_admin_client.mint(&contract_id, &1_000_000_000_000i128);
-    (admin, client, usdc_token)
-}
-
 #[test]
 fn test_process_refund_deducts_fee_from_requester() {
     let env = Env::default();
@@ -2207,7 +2193,7 @@ fn test_create_payment_idempotency_retry_returns_same_payment() {
         memo_type: None,
         token_address: None,
         client_token: client_token.clone(),
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
 
     let first = client.create_payment(&args);
@@ -2243,7 +2229,7 @@ fn test_create_payment_idempotency_different_payment_id_fails() {
         memo_type: None,
         token_address: None,
         client_token: client_token.clone(),
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
 
     // First call succeeds
@@ -2282,7 +2268,7 @@ fn test_create_payment_without_idempotency_token_fails_on_retry() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None,
+        metadata_hash: None, metadata: None,
     };
 
     client.create_payment(&args);


### PR DESCRIPTION
…84, #286)

closes #286 - PaymentCharge metadata:
- Add metadata: Option<Map<String, String>> to PaymentCharge and CreatePaymentArgs
- Validate max 20 keys and 256 chars per value on create_payment and create_payments_batch
- New error variants: MetadataTooLarge (#49) and MetadataValueTooLong (#47)
- Persist and return metadata via get_payment
- Include metadata in PAYMENT/CREATED event payload
- Fix duplicate discriminant: InsufficientTreasuryBalance and MetadataTooLarge both had code 46

close #284 - Standardize on-chain event schema:
- Normalize all events to consistent 2-tuple topic (namespace: Symbol, action: Symbol)
- stream.rs: move stream_id from topic[2] to payload[0] across all STREAM/* events
- lib.rs: normalize SUBSCRIPTION/EXPIRED, SUBSCRIPTION/CANCELLED, PAYMENT/CREATED
- Create docs/events.md with complete event catalog for all namespaces

Tests:
- Add payment_metadata_test.rs with 7 tests covering nil metadata, valid metadata, max-key boundary (20 keys ok, 21 fails), value-length boundary (256 ok, 257 fails), metadata persisted via get_payment, and 2-tuple topic assertion
- Fix pre-existing compile errors exposed after merchant_registry_test.rs syntax fix: duplicate top_up_stream, MockDexRouterClient, setup_refund_manager_with_token, missing vec/format imports, missing &None args in stream_test, .unwrap() on void returns

