### PR TITLE
Add status filter to get_merchant_payments_paginated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `get_merchant_payments_paginated` optional `status_filter` parameter to paginate merchant payments by `PaymentStatus` (closes #280)
 - `scripts/deploy_testnet.sh`: builds all contract WASMs and deploys them to the configured Stellar network; writes resulting contract IDs to `.env.testnet`; fails fast if `STELLAR_SECRET_KEY` or `STELLAR_NETWORK` are unset (closes #294)
 - `docs/local-invoke.md`: CLI recipe sections for `create_refund`, `process_refund`, `create_dispute`, `set_dispute_deadline`, `resolve_dispute_with_refund`, `verify_payment`, `settle_payment`, `set_paused`, `set_rate`, `create_link`, and `use_link` — each with full command, expected output, and error scenarios (closes #299)
 - `docs/local-invoke.md`: Deployment section documenting how to run `scripts/deploy_testnet.sh` and load `.env.testnet`

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -1522,7 +1522,7 @@ fn test_first_payout_address_set_produces_no_history() {
     assert_eq!(merchant.payout_address, Some(new_addr));
 
     // History is empty because there was no prior address
-    let history = client.get_payout_history(&merchant_id).unwrap();
+    let history = client.get_payout_history(&merchant_id);
     assert_eq!(history.len(), 0, "Expected no history on first set");
 }
 
@@ -1565,7 +1565,7 @@ fn test_payout_address_update_appends_old_to_history_and_emits_event() {
     let merchant = client.get_merchant(&merchant_id);
     assert_eq!(merchant.payout_address, Some(second_addr.clone()));
 
-    let history = client.get_payout_history(&merchant_id).unwrap();
+    let history = client.get_payout_history(&merchant_id);
     assert_eq!(history.len(), 1, "Expected one history entry");
     assert_eq!(history.get(0).unwrap(), first_addr);
 
@@ -1622,7 +1622,7 @@ fn test_unchanged_payout_address_produces_no_history_and_no_event() {
         &None,
     );
 
-    let history = client.get_payout_history(&merchant_id).unwrap();
+    let history = client.get_payout_history(&merchant_id);
     assert_eq!(history.len(), 0, "Expected no history when address is unchanged");
 
     // Count PAYOUT_UPDATED events — should be zero
@@ -1689,7 +1689,7 @@ fn test_get_payout_history_returns_all_previous_addresses_in_order() {
         &None,
     );
 
-    let history = client.get_payout_history(&merchant_id).unwrap();
+    let history = client.get_payout_history(&merchant_id);
     assert_eq!(history.len(), 2, "Expected two history entries");
     assert_eq!(history.get(0).unwrap(), addr1, "First history entry should be addr1");
     assert_eq!(history.get(1).unwrap(), addr2, "Second history entry should be addr2");

--- a/fluxapay/src/subscription_test.rs
+++ b/fluxapay/src/subscription_test.rs
@@ -2,7 +2,7 @@ use crate::{
     access_control::role_oracle, BillingInterval, Error, RefundManager, RefundManagerClient,
     SubscriptionStatus,
 };
-use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env, String, Symbol, vec, TryIntoVal};
+use soroban_sdk::{testutils::Address as _, testutils::Events, testutils::Ledger as _, Address, Env, String, Symbol, vec, TryIntoVal};
 
 // ── Shared setup helpers ──────────────────────────────────────────────────────
 
@@ -96,7 +96,7 @@ fn test_create_subscription_plan_by_merchant_stores_plan() {
     env.mock_all_auths();
     let (client, _admin, merchant, plan_id) = setup_with_plan(&env);
 
-    let plan = client.get_subscription_plan(&plan_id).expect("plan should exist");
+    let plan = client.get_subscription_plan(&plan_id);
     assert_eq!(plan.plan_id, plan_id);
     assert_eq!(plan.merchant_id, merchant);
     assert_eq!(plan.amount, 1_000_000_i128);
@@ -135,7 +135,7 @@ fn test_subscribe_to_active_plan_creates_subscription_and_emits_event() {
     let sub_id = client.subscribe(&payer, &plan_id, &None, &None, &None);
 
     // Subscription exists and is Active
-    let sub = client.get_subscription(&sub_id).expect("subscription should exist");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.subscription_id, sub_id);
     assert_eq!(sub.payer_address, payer);
     assert_eq!(sub.status, SubscriptionStatus::Active);
@@ -147,8 +147,14 @@ fn test_subscribe_to_active_plan_creates_subscription_and_emits_event() {
         if topics.len() < 2 {
             return false;
         }
-        let t0: Result<Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
-        let t1: Result<Symbol, _> = topics.get(1).unwrap().try_into_val(&env);
+        let Some(v0) = topics.get(0) else {
+            return false;
+        };
+        let Some(v1) = topics.get(1) else {
+            return false;
+        };
+        let t0: Result<Symbol, _> = v0.try_into_val(&env);
+        let t1: Result<Symbol, _> = v1.try_into_val(&env);
         matches!(
             (t0, t1),
             (Ok(a), Ok(b)) if a == Symbol::new(&env, "SUBSCRIPTION") && b == Symbol::new(&env, "CREATED")
@@ -184,7 +190,7 @@ fn test_pause_subscription_by_payer_becomes_paused() {
 
     client.pause_subscription(&payer, &sub_id);
 
-    let sub = client.get_subscription(&sub_id).expect("subscription should exist");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.status, SubscriptionStatus::Paused);
 }
 
@@ -202,12 +208,13 @@ fn test_resume_subscription_by_payer_becomes_active_with_updated_payment_at() {
     client.pause_subscription(&payer, &sub_id);
 
     // Advance time
-    env.ledger().with_mut(|li| li.timestamp += 1_000);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 1_000);
 
     let before_resume = env.ledger().timestamp();
     client.resume_subscription(&payer, &sub_id);
 
-    let sub = client.get_subscription(&sub_id).expect("subscription should exist");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.status, SubscriptionStatus::Active);
     // next_payment_at must be after the resume timestamp
     assert!(
@@ -230,7 +237,7 @@ fn test_cancel_subscription_by_payer_becomes_cancelled() {
 
     client.cancel_subscription(&payer, &sub_id);
 
-    let sub = client.get_subscription(&sub_id).expect("subscription should exist");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.status, SubscriptionStatus::Cancelled);
 }
 
@@ -270,6 +277,6 @@ fn test_deactivate_subscription_plan_by_merchant_marks_inactive() {
 
     client.deactivate_subscription_plan(&merchant, &plan_id);
 
-    let plan = client.get_subscription_plan(&plan_id).expect("plan should exist");
+    let plan = client.get_subscription_plan(&plan_id);
     assert!(!plan.active, "Plan should be inactive after deactivation");
 }


### PR DESCRIPTION
## Summary
- `get_merchant_payments_paginated` already accepts optional `status_filter` on main
- Fixes subscription and merchant registry unit tests that failed to compile on soroban-sdk 23

Closes #280

## Test plan
- [x] `cargo test -p fluxapay test_get_merchant_payments_paginated_filters_by_status`