### PR TITLE
[327] Add tests for swap_and_pay with mock DEX router

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -6092,4 +6092,6 @@ pub mod gas_estimator;
 pub use gas_estimator::{CostEstimate, GasEstimator, GasEstimatorClient, Operation};
 
 #[cfg(test)]
+mod mock_dex_router;
+#[cfg(test)]
 mod swap_test;

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -1,6 +1,9 @@
-﻿use super::merchant_registry::*;
+use super::merchant_registry::*;
 use crate::{PaymentProcessor, PaymentProcessorClient, RefundManager, RefundManagerClient};
-use soroban_sdk::{testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String, Symbol, TryIntoVal};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String, Symbol,
+    TryIntoVal,
+};
 
 #[test]
 fn test_merchant_registration() {
@@ -360,7 +363,8 @@ fn test_unverified_merchant_cannot_create_payment() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None, metadata: None,
+        metadata_hash: None,
+        metadata: None,
     };
 
     // This should panic with Unauthorized error
@@ -421,7 +425,8 @@ fn test_verified_merchant_can_create_payment() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None, metadata: None,
+        metadata_hash: None,
+        metadata: None,
     };
 
     let payment = payment_client.create_payment(&args);
@@ -661,7 +666,12 @@ fn test_suspend_merchant_unauthorized() {
         &None,
     );
 
-    client.suspend_merchant(&attacker, &merchant_id, &String::from_str(&env, "Reason"), &0u64);
+    client.suspend_merchant(
+        &attacker,
+        &merchant_id,
+        &String::from_str(&env, "Reason"),
+        &0u64,
+    );
 }
 
 // Tests for issue #208: Content-Addressable Merchant Profiles
@@ -1223,7 +1233,7 @@ fn test_verify_merchant_with_oracle_signature() {
     );
 
     let signature = String::from_str(&env, "0x1234567890abcdef");
-    
+
     // Verify merchant with oracle signature
     client.verify_merchant_with_signature(&admin, &merchant_id, &Some(signature.clone()));
 
@@ -1254,9 +1264,14 @@ fn test_set_kyc_tier_with_oracle_signature() {
     );
 
     let signature = String::from_str(&env, "0xabcdef1234567890");
-    
+
     // Set KYC tier with oracle signature
-    client.set_kyc_tier_with_signature(&admin, &merchant_id, &KycTier::Full, &Some(signature.clone()));
+    client.set_kyc_tier_with_signature(
+        &admin,
+        &merchant_id,
+        &KycTier::Full,
+        &Some(signature.clone()),
+    );
 
     let merchant = client.get_merchant(&merchant_id);
     assert_eq!(merchant.oracle_signature, Some(signature));
@@ -1310,11 +1325,15 @@ fn test_basic_tier_cap_enforced() {
     env.mock_all_auths();
     env.ledger().with_mut(|li| li.timestamp = 1_000_000);
 
-    let (admin, payment_client, registry_client, merchant, oracle) =
-        setup_volume_cap_env(&env);
+    let (admin, payment_client, registry_client, merchant, oracle) = setup_volume_cap_env(&env);
 
     // Set merchant to Basic tier ($10,000 cap = 100_000_000_000 stroops)
-    registry_client.set_kyc_tier_with_signature(&admin, &merchant, &KycTier::Basic, &Some(String::from_str(&env, "sig")));
+    registry_client.set_kyc_tier_with_signature(
+        &admin,
+        &merchant,
+        &KycTier::Basic,
+        &Some(String::from_str(&env, "sig")),
+    );
 
     let deposit = Address::generate(&env);
 
@@ -1332,7 +1351,8 @@ fn test_basic_tier_cap_enforced() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None, metadata: None,
+        metadata_hash: None,
+        metadata: None,
     });
     payment_client.verify_payment(
         &oracle,
@@ -1356,7 +1376,8 @@ fn test_basic_tier_cap_enforced() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None, metadata: None,
+        metadata_hash: None,
+        metadata: None,
     });
 
     let result = payment_client.try_verify_payment(
@@ -1375,11 +1396,15 @@ fn test_business_tier_no_cap() {
     env.mock_all_auths();
     env.ledger().with_mut(|li| li.timestamp = 1_000_000);
 
-    let (admin, payment_client, registry_client, merchant, oracle) =
-        setup_volume_cap_env(&env);
+    let (admin, payment_client, registry_client, merchant, oracle) = setup_volume_cap_env(&env);
 
     // Business tier: unlimited
-    registry_client.set_kyc_tier_with_signature(&admin, &merchant, &KycTier::Business, &Some(String::from_str(&env, "sig")));
+    registry_client.set_kyc_tier_with_signature(
+        &admin,
+        &merchant,
+        &KycTier::Business,
+        &Some(String::from_str(&env, "sig")),
+    );
 
     let deposit = Address::generate(&env);
 
@@ -1397,7 +1422,8 @@ fn test_business_tier_no_cap() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None, metadata: None,
+        metadata_hash: None,
+        metadata: None,
     });
     payment_client.verify_payment(
         &oracle,
@@ -1415,10 +1441,14 @@ fn test_volume_resets_next_month() {
     // Start at beginning of a month epoch
     env.ledger().with_mut(|li| li.timestamp = 2_592_000); // epoch 1
 
-    let (admin, payment_client, registry_client, merchant, oracle) =
-        setup_volume_cap_env(&env);
+    let (admin, payment_client, registry_client, merchant, oracle) = setup_volume_cap_env(&env);
 
-    registry_client.set_kyc_tier_with_signature(&admin, &merchant, &KycTier::Basic, &Some(String::from_str(&env, "sig")));
+    registry_client.set_kyc_tier_with_signature(
+        &admin,
+        &merchant,
+        &KycTier::Basic,
+        &Some(String::from_str(&env, "sig")),
+    );
 
     let deposit = Address::generate(&env);
 
@@ -1436,7 +1466,8 @@ fn test_volume_resets_next_month() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None, metadata: None,
+        metadata_hash: None,
+        metadata: None,
     });
     payment_client.verify_payment(
         &oracle,
@@ -1463,7 +1494,8 @@ fn test_volume_resets_next_month() {
         memo_type: None,
         token_address: None,
         client_token: None,
-        metadata_hash: None, metadata: None,
+        metadata_hash: None,
+        metadata: None,
     });
     payment_client.verify_payment(
         &oracle,
@@ -1522,7 +1554,7 @@ fn test_first_payout_address_set_produces_no_history() {
     assert_eq!(merchant.payout_address, Some(new_addr));
 
     // History is empty because there was no prior address
-    let history = client.get_payout_history(&merchant_id).unwrap();
+    let history = client.get_payout_history(&merchant_id);
     assert_eq!(history.len(), 0, "Expected no history on first set");
 }
 
@@ -1565,7 +1597,7 @@ fn test_payout_address_update_appends_old_to_history_and_emits_event() {
     let merchant = client.get_merchant(&merchant_id);
     assert_eq!(merchant.payout_address, Some(second_addr.clone()));
 
-    let history = client.get_payout_history(&merchant_id).unwrap();
+    let history = client.get_payout_history(&merchant_id);
     assert_eq!(history.len(), 1, "Expected one history entry");
     assert_eq!(history.get(0).unwrap(), first_addr);
 
@@ -1622,8 +1654,12 @@ fn test_unchanged_payout_address_produces_no_history_and_no_event() {
         &None,
     );
 
-    let history = client.get_payout_history(&merchant_id).unwrap();
-    assert_eq!(history.len(), 0, "Expected no history when address is unchanged");
+    let history = client.get_payout_history(&merchant_id);
+    assert_eq!(
+        history.len(),
+        0,
+        "Expected no history when address is unchanged"
+    );
 
     // Count PAYOUT_UPDATED events — should be zero
     let events = env.events().all();
@@ -1640,7 +1676,10 @@ fn test_unchanged_payout_address_produces_no_history_and_no_event() {
                 if a == Symbol::new(&env, "MERCHANT") && b == Symbol::new(&env, "PAYOUT_UPDATED")
         )
     }).count();
-    assert_eq!(payout_updated_count, 0, "Expected no PAYOUT_UPDATED events when address unchanged");
+    assert_eq!(
+        payout_updated_count, 0,
+        "Expected no PAYOUT_UPDATED events when address unchanged"
+    );
 }
 
 /// get_payout_history returns the full list of previous addresses in order.
@@ -1689,8 +1728,16 @@ fn test_get_payout_history_returns_all_previous_addresses_in_order() {
         &None,
     );
 
-    let history = client.get_payout_history(&merchant_id).unwrap();
+    let history = client.get_payout_history(&merchant_id);
     assert_eq!(history.len(), 2, "Expected two history entries");
-    assert_eq!(history.get(0).unwrap(), addr1, "First history entry should be addr1");
-    assert_eq!(history.get(1).unwrap(), addr2, "Second history entry should be addr2");
+    assert_eq!(
+        history.get(0).unwrap(),
+        addr1,
+        "First history entry should be addr1"
+    );
+    assert_eq!(
+        history.get(1).unwrap(),
+        addr2,
+        "Second history entry should be addr2"
+    );
 }

--- a/fluxapay/src/mock_dex_router.rs
+++ b/fluxapay/src/mock_dex_router.rs
@@ -1,0 +1,88 @@
+#![cfg(test)]
+
+use soroban_sdk::{contract, contracterror, contractimpl, vec, Address, Env, Symbol, Vec};
+
+pub const OUTPUT_KEY: &str = "output";
+pub const FAIL_SWAP_KEY: &str = "fail_swap";
+
+#[contracterror]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MockDexError {
+    SwapFailed = 1,
+    InvalidPath = 2,
+    InsufficientOutput = 3,
+}
+
+#[contract]
+pub struct MockDexRouter;
+
+#[contractimpl]
+impl MockDexRouter {
+    fn read_output(env: &Env) -> Option<i128> {
+        env.storage()
+            .persistent()
+            .get(&Symbol::new(env, OUTPUT_KEY))
+    }
+
+    fn build_amounts(env: &Env, amount_in: i128, output: i128) -> Vec<i128> {
+        let mut amounts = vec![env];
+        amounts.push_back(amount_in);
+        amounts.push_back(output);
+        amounts
+    }
+
+    pub fn get_amounts_out(env: Env, amount_in: i128, path: Vec<Address>) -> Vec<i128> {
+        if path.len() < 2 {
+            return vec![&env];
+        }
+
+        match Self::read_output(&env) {
+            Some(output) => Self::build_amounts(&env, amount_in, output),
+            None => Self::build_amounts(&env, amount_in, amount_in),
+        }
+    }
+
+    pub fn swap_exact_tokens_for_tokens(
+        env: Env,
+        amount_in: i128,
+        amount_out_min: i128,
+        path: Vec<Address>,
+        _to: Address,
+        _deadline: u64,
+    ) -> Result<Vec<i128>, MockDexError> {
+        if path.len() < 2 {
+            return Err(MockDexError::InvalidPath);
+        }
+
+        let fail_swap: bool = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(&env, FAIL_SWAP_KEY))
+            .unwrap_or(false);
+        if fail_swap {
+            return Err(MockDexError::SwapFailed);
+        }
+
+        let stored_output = Self::read_output(&env);
+        match stored_output {
+            Some(output) => {
+                if output < amount_out_min {
+                    return Err(MockDexError::InsufficientOutput);
+                }
+                Ok(Self::build_amounts(&env, amount_in, output))
+            }
+            None => Err(MockDexError::SwapFailed),
+        }
+    }
+}
+
+pub fn configure_mock_dex(env: &Env, mock_dex: &Address, output: i128, fail_swap: bool) {
+    env.as_contract(mock_dex, || {
+        env.storage()
+            .persistent()
+            .set(&Symbol::new(env, OUTPUT_KEY), &output);
+        env.storage()
+            .persistent()
+            .set(&Symbol::new(env, FAIL_SWAP_KEY), &fail_swap);
+    });
+}

--- a/fluxapay/src/subscription_test.rs
+++ b/fluxapay/src/subscription_test.rs
@@ -2,7 +2,10 @@ use crate::{
     access_control::role_oracle, BillingInterval, Error, RefundManager, RefundManagerClient,
     SubscriptionStatus,
 };
-use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env, String, Symbol, vec, TryIntoVal};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events, testutils::Ledger, vec, Address, Env, String,
+    Symbol, TryIntoVal,
+};
 
 // ── Shared setup helpers ──────────────────────────────────────────────────────
 
@@ -22,22 +25,11 @@ fn setup_refund_manager(env: &Env) -> (Address, RefundManagerClient<'_>) {
 
 /// Create a merchant with MERCHANT role and a subscription plan, returning
 /// `(client, admin, merchant, plan_id)`.
-fn setup_with_plan(
-    env: &Env,
-) -> (
-    RefundManagerClient<'_>,
-    Address,
-    Address,
-    String,
-) {
+fn setup_with_plan(env: &Env) -> (RefundManagerClient<'_>, Address, Address, String) {
     let (admin, client) = setup_refund_manager(env);
 
     let merchant = Address::generate(env);
-    client.grant_role(
-        &admin,
-        &Symbol::new(env, "MERCHANT"),
-        &merchant,
-    );
+    client.grant_role(&admin, &Symbol::new(env, "MERCHANT"), &merchant);
 
     let plan_id = String::from_str(env, "plan_weekly");
     client.create_subscription_plan(
@@ -96,7 +88,7 @@ fn test_create_subscription_plan_by_merchant_stores_plan() {
     env.mock_all_auths();
     let (client, _admin, merchant, plan_id) = setup_with_plan(&env);
 
-    let plan = client.get_subscription_plan(&plan_id).expect("plan should exist");
+    let plan = client.get_subscription_plan(&plan_id);
     assert_eq!(plan.plan_id, plan_id);
     assert_eq!(plan.merchant_id, merchant);
     assert_eq!(plan.amount, 1_000_000_i128);
@@ -135,7 +127,7 @@ fn test_subscribe_to_active_plan_creates_subscription_and_emits_event() {
     let sub_id = client.subscribe(&payer, &plan_id, &None, &None, &None);
 
     // Subscription exists and is Active
-    let sub = client.get_subscription(&sub_id).expect("subscription should exist");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.subscription_id, sub_id);
     assert_eq!(sub.payer_address, payer);
     assert_eq!(sub.status, SubscriptionStatus::Active);
@@ -169,7 +161,10 @@ fn test_subscribe_to_inactive_plan_fails() {
 
     let payer = Address::generate(&env);
     let result = client.try_subscribe(&payer, &plan_id, &None, &None, &None);
-    assert!(result.is_err(), "Expected error when subscribing to inactive plan");
+    assert!(
+        result.is_err(),
+        "Expected error when subscribing to inactive plan"
+    );
 }
 
 /// Payer can pause an active subscription and it becomes Paused.
@@ -184,7 +179,7 @@ fn test_pause_subscription_by_payer_becomes_paused() {
 
     client.pause_subscription(&payer, &sub_id);
 
-    let sub = client.get_subscription(&sub_id).expect("subscription should exist");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.status, SubscriptionStatus::Paused);
 }
 
@@ -207,7 +202,7 @@ fn test_resume_subscription_by_payer_becomes_active_with_updated_payment_at() {
     let before_resume = env.ledger().timestamp();
     client.resume_subscription(&payer, &sub_id);
 
-    let sub = client.get_subscription(&sub_id).expect("subscription should exist");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.status, SubscriptionStatus::Active);
     // next_payment_at must be after the resume timestamp
     assert!(
@@ -230,7 +225,7 @@ fn test_cancel_subscription_by_payer_becomes_cancelled() {
 
     client.cancel_subscription(&payer, &sub_id);
 
-    let sub = client.get_subscription(&sub_id).expect("subscription should exist");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.status, SubscriptionStatus::Cancelled);
 }
 
@@ -257,8 +252,14 @@ fn test_get_payer_subscriptions_returns_all_for_payer() {
         }
         v
     };
-    assert!(ids.contains(&sub_id_1), "sub_id_1 not found in payer subscriptions");
-    assert!(ids.contains(&sub_id_2), "sub_id_2 not found in payer subscriptions");
+    assert!(
+        ids.contains(&sub_id_1),
+        "sub_id_1 not found in payer subscriptions"
+    );
+    assert!(
+        ids.contains(&sub_id_2),
+        "sub_id_2 not found in payer subscriptions"
+    );
 }
 
 /// Merchant can deactivate a plan; subsequent subscribe attempts fail.
@@ -270,6 +271,6 @@ fn test_deactivate_subscription_plan_by_merchant_marks_inactive() {
 
     client.deactivate_subscription_plan(&merchant, &plan_id);
 
-    let plan = client.get_subscription_plan(&plan_id).expect("plan should exist");
+    let plan = client.get_subscription_plan(&plan_id);
     assert!(!plan.active, "Plan should be inactive after deactivation");
 }

--- a/fluxapay/src/swap_test.rs
+++ b/fluxapay/src/swap_test.rs
@@ -1,58 +1,11 @@
 use crate::{
     merchant_registry::{MerchantRegistry, MerchantRegistryClient},
-    PaymentProcessor, PaymentProcessorClient, SwapAndPayArgs,
+    mock_dex_router::{configure_mock_dex, MockDexRouter},
+    Error, PaymentProcessor, PaymentProcessorClient, PaymentStatus, SwapAndPayArgs,
 };
 use soroban_sdk::{
-    contract, contractimpl, contracterror, testutils::Address as _, vec, Address,
-    Env, String, Symbol, Vec,
+    testutils::Address as _, testutils::Events as _, vec, Address, Env, String, Symbol, Vec,
 };
-
-#[contracterror]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum MockDexError {
-    SwapFailed = 1,
-    InvalidPath = 2,
-    InsufficientOutput = 3,
-}
-
-#[contract]
-pub struct MockDexRouter;
-
-#[cfg_attr(
-    any(not(target_arch = "wasm32"), feature = "contract-payment-processor"),
-    contractimpl
-)]
-impl MockDexRouter {
-    pub fn swap_exact_tokens_for_tokens(
-        env: Env,
-        _amount_in: i128,
-        amount_out_min: i128,
-        path: Vec<Address>,
-        _to: Address,
-        _deadline: u64,
-    ) -> Result<Vec<i128>, MockDexError> {
-        if path.len() < 2 {
-            return Err(MockDexError::InvalidPath);
-        }
-
-        let stored_output = env.storage().persistent().get::<_, i128>(&Symbol::new(&env, "output"));
-
-        let amounts = match stored_output {
-            Some(output) => {
-                if output < amount_out_min {
-                    return Err(MockDexError::InsufficientOutput);
-                }
-                let mut result = vec![&env];
-                result.push_back(_amount_in);
-                result.push_back(output);
-                result
-            }
-            None => return Err(MockDexError::SwapFailed),
-        };
-
-        Ok(amounts)
-    }
-}
 
 fn setup_swap_test_env(
     env: &Env,
@@ -78,120 +31,227 @@ fn setup_swap_test_env(
     let token_out = Address::generate(env);
     payment_client.allow_token(&admin, &token_out);
 
-    (
-        admin,
-        payment_client,
-        merchant_client,
-        token_in,
-        token_out,
-    )
+    (admin, payment_client, merchant_client, token_in, token_out)
+}
+
+fn register_verified_merchant(
+    env: &Env,
+    admin: &Address,
+    payment_client: &PaymentProcessorClient<'_>,
+    merchant_client: &MerchantRegistryClient<'_>,
+) -> Address {
+    let merchant = Address::generate(env);
+    merchant_client.register_merchant(
+        &merchant,
+        &String::from_str(env, "TestShop"),
+        &String::from_str(env, "USD"),
+        &None,
+        &None,
+        &None,
+    );
+    merchant_client.verify_merchant(admin, &merchant);
+    payment_client.grant_role(admin, &Symbol::new(env, "MERCHANT"), &merchant);
+    merchant
+}
+
+fn build_swap_args(
+    env: &Env,
+    payment_id: &str,
+    payer: &Address,
+    merchant: &Address,
+    deposit_address: &Address,
+    token_in: &Address,
+    token_out: &Address,
+    mock_dex: &Address,
+    amount: i128,
+    amount_in: i128,
+) -> SwapAndPayArgs {
+    let path = vec![env, token_in.clone(), token_out.clone()];
+    SwapAndPayArgs {
+        payer: payer.clone(),
+        payment_id: String::from_str(env, payment_id),
+        merchant_id: merchant.clone(),
+        amount,
+        currency: Symbol::new(env, "USDC"),
+        deposit_address: deposit_address.clone(),
+        token_in: token_in.clone(),
+        amount_in,
+        amount_out_min: amount,
+        path,
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        dex_router: mock_dex.clone(),
+        fx_oracle: None,
+        oracle_pair: None,
+        max_deviation_bps: 0,
+    }
 }
 
 #[test]
 fn test_swap_and_pay_happy_path_with_mock_dex() {
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, payment_client, merchant_client, token_in, token_out) =
-        setup_swap_test_env(&env);
+    let (admin, payment_client, merchant_client, token_in, token_out) = setup_swap_test_env(&env);
 
-    // Register a mock DEX router
     let mock_dex = env.register(MockDexRouter, ());
+    configure_mock_dex(&env, &mock_dex, 10_000, false);
 
-    // Set up the mock to return a specific amount_out
-    env.storage()
-        .persistent()
-        .set(&Symbol::new(&env, "output"), &10_000i128);
-
-    // Register merchant
-    let merchant = Address::generate(&env);
-    merchant_client.register_merchant(
-        &merchant,
-        &String::from_str(&env, "TestShop"),
-        &String::from_str(&env, "USD"),
-        &None,
-        &None,
-        &None,
-    );
-    merchant_client.verify_merchant(&admin, &merchant);
-    payment_client.grant_role(&admin, &Symbol::new(&env, "MERCHANT"), &merchant);
-
+    let merchant = register_verified_merchant(&env, &admin, &payment_client, &merchant_client);
     let payer = Address::generate(&env);
     let deposit_address = Address::generate(&env);
+    let payment_id = String::from_str(&env, "SWAP_TEST_001");
 
-    let path = vec![&env, token_in.clone(), token_out.clone()];
-    let args = SwapAndPayArgs {
-        payer: payer.clone(),
-        payment_id: String::from_str(&env, "SWAP_TEST_001"),
-        merchant_id: merchant.clone(),
-        amount: 9_900,
-        currency: Symbol::new(&env, "USDC"),
-        deposit_address: deposit_address.clone(),
-        token_in: token_in.clone(),
-        amount_in: 10_000,
-        amount_out_min: 9_900,
-        path,
-        expires_at: Some(env.ledger().timestamp() + 3600),
-        dex_router: mock_dex.clone(),
-        fx_oracle: None,
-        oracle_pair: None,
-        max_deviation_bps: 0,
-    };
+    let args = build_swap_args(
+        &env,
+        "SWAP_TEST_001",
+        &payer,
+        &merchant,
+        &deposit_address,
+        &token_in,
+        &token_out,
+        &mock_dex,
+        9_900,
+        10_000,
+    );
 
+    let events_before = env.events().all().len();
     let payment = payment_client.swap_and_pay(&args);
-    assert_eq!(payment.payment_id, args.payment_id);
-    assert_eq!(payment.status, crate::PaymentStatus::Settled);
+    let events = env.events().all();
+    assert!(
+        events.len() > events_before,
+        "swap_and_pay should emit events"
+    );
+
+    assert_eq!(payment.payment_id, payment_id);
+    assert_eq!(payment.amount, 9_900);
+    assert_eq!(payment.status, PaymentStatus::Pending);
+
+    let stored = payment_client.get_payment(&payment_id);
+    assert_eq!(stored.amount, 9_900);
+    assert_eq!(stored.original_token, Some(token_in));
+    assert!(stored.swap_path.is_some());
+
+    assert!(
+        events.len() > events_before,
+        "swap_and_pay should emit contract events"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|(_, topics, _)| topics.len() == 2 || topics.len() == 3),
+        "expected structured payment events after swap_and_pay"
+    );
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #28)")]
 fn test_swap_and_pay_failure_with_mock_dex_insufficient_output() {
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, payment_client, merchant_client, token_in, token_out) =
-        setup_swap_test_env(&env);
+    let (admin, payment_client, merchant_client, token_in, token_out) = setup_swap_test_env(&env);
 
-    // Register a mock DEX router that returns insufficient output
     let mock_dex = env.register(MockDexRouter, ());
+    configure_mock_dex(&env, &mock_dex, 8_000, false);
 
-    // Set up the mock to return less than minimum required
-    env.storage()
-        .persistent()
-        .set(&Symbol::new(&env, "output"), &8_000i128);
+    let merchant = register_verified_merchant(&env, &admin, &payment_client, &merchant_client);
+    let payer = Address::generate(&env);
+    let deposit_address = Address::generate(&env);
+    let payment_id = String::from_str(&env, "SWAP_TEST_002");
 
-    // Register merchant
-    let merchant = Address::generate(&env);
-    merchant_client.register_merchant(
+    let args = build_swap_args(
+        &env,
+        "SWAP_TEST_002",
+        &payer,
         &merchant,
-        &String::from_str(&env, "TestShop"),
-        &String::from_str(&env, "USD"),
-        &None,
-        &None,
-        &None,
+        &deposit_address,
+        &token_in,
+        &token_out,
+        &mock_dex,
+        9_900,
+        10_000,
     );
-    merchant_client.verify_merchant(&admin, &merchant);
-    payment_client.grant_role(&admin, &Symbol::new(&env, "MERCHANT"), &merchant);
 
+    let result = payment_client.try_swap_and_pay(&args);
+    assert!(result.is_err(), "expected swap_and_pay to fail");
+    assert!(
+        payment_client.try_get_payment(&payment_id).is_err(),
+        "payment should not be stored when swap fails"
+    );
+}
+
+#[test]
+fn test_swap_and_pay_failure_when_mock_dex_swap_errors() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, merchant_client, token_in, token_out) = setup_swap_test_env(&env);
+
+    let mock_dex = env.register(MockDexRouter, ());
+    configure_mock_dex(&env, &mock_dex, 10_000, true);
+
+    let merchant = register_verified_merchant(&env, &admin, &payment_client, &merchant_client);
+    let payer = Address::generate(&env);
+    let deposit_address = Address::generate(&env);
+    let payment_id = String::from_str(&env, "SWAP_TEST_003");
+
+    let args = build_swap_args(
+        &env,
+        "SWAP_TEST_003",
+        &payer,
+        &merchant,
+        &deposit_address,
+        &token_in,
+        &token_out,
+        &mock_dex,
+        9_900,
+        10_000,
+    );
+
+    let result = payment_client.try_swap_and_pay(&args);
+    assert!(
+        result.is_err(),
+        "expected swap_and_pay to propagate DEX error"
+    );
+    assert!(
+        payment_client.try_get_payment(&payment_id).is_err(),
+        "payment should not be stored when DEX swap errors"
+    );
+}
+
+#[test]
+fn test_swap_and_pay_rejects_invalid_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, merchant_client, token_in, token_out) = setup_swap_test_env(&env);
+
+    let mock_dex = env.register(MockDexRouter, ());
+    configure_mock_dex(&env, &mock_dex, 10_000, false);
+
+    let merchant = register_verified_merchant(&env, &admin, &payment_client, &merchant_client);
     let payer = Address::generate(&env);
     let deposit_address = Address::generate(&env);
 
-    let path = vec![&env, token_in.clone(), token_out.clone()];
-    let args = SwapAndPayArgs {
-        payer: payer.clone(),
-        payment_id: String::from_str(&env, "SWAP_TEST_002"),
-        merchant_id: merchant.clone(),
-        amount: 9_900,
-        currency: Symbol::new(&env, "USDC"),
-        deposit_address: deposit_address.clone(),
-        token_in: token_in.clone(),
-        amount_in: 10_000,
-        amount_out_min: 9_900,
-        path,
-        expires_at: Some(env.ledger().timestamp() + 3600),
-        dex_router: mock_dex.clone(),
-        fx_oracle: None,
-        oracle_pair: None,
-        max_deviation_bps: 0,
-    };
+    let mut zero_amount_args = build_swap_args(
+        &env,
+        "SWAP_TEST_ZERO_AMOUNT",
+        &payer,
+        &merchant,
+        &deposit_address,
+        &token_in,
+        &token_out,
+        &mock_dex,
+        0,
+        10_000,
+    );
+    let zero_amount_result = payment_client.try_swap_and_pay(&zero_amount_args);
+    assert_eq!(zero_amount_result, Err(Ok(Error::InvalidAmount)));
+    assert!(payment_client
+        .try_get_payment(&zero_amount_args.payment_id)
+        .is_err());
 
-    payment_client.swap_and_pay(&args);
+    zero_amount_args.payment_id = String::from_str(&env, "SWAP_TEST_ZERO_AMOUNT_IN");
+    zero_amount_args.amount = 9_900;
+    zero_amount_args.amount_in = 0;
+    let zero_amount_in_result = payment_client.try_swap_and_pay(&zero_amount_args);
+    assert_eq!(zero_amount_in_result, Err(Ok(Error::InvalidAmount)));
+    assert!(payment_client
+        .try_get_payment(&zero_amount_args.payment_id)
+        .is_err());
 }


### PR DESCRIPTION
## Summary
- Add a configurable `MockDexRouter` test contract with `get_amounts_out` and `swap_exact_tokens_for_tokens` for Soroban integration tests
- Cover `swap_and_pay` happy path (payment storage, swap metadata, event emission), DEX failure paths (insufficient quote and swap error), and invalid amount validation
- Fix compile errors in recently merged subscription and payout-history tests so the workspace builds

Closes #327

## Test plan
- [x] `cargo test -p fluxapay swap_test`
- [x] All four swap tests pass: happy path, insufficient output, swap error, invalid amount