### PR TITLE
feat(sdk): add fx oracle methods to typescript sdk

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -40,7 +40,7 @@ async function main() {
 
 ## Features
 
-- **High-level Wrapper**: `FluxapayClient`, `RefundManagerClient`, and `MerchantRegistryClient` simplify complex contract interactions.
+- **High-level Wrapper**: `FluxapayClient`, `RefundManagerClient`, `MerchantRegistryClient`, and `FxOracleClient` simplify complex contract interactions.
 - **Typed Interfaces**: Full TypeScript support for all contract models (`Merchant`, `Payment`, `Refund`, etc.).
 - **Automatic Simulation**: Built-in support for Soroban transaction simulation.
 - **Network Presets**: Easy switching between `testnet` and `mainnet`.
@@ -126,6 +126,74 @@ async function manageMerchant() {
   // Reinstate a suspended merchant
   await merchantClient.reinstateMerchant("G...", "merchant_001");
 }
+```
+
+## FxOracleClient
+
+The `FxOracleClient` provides methods for querying and publishing FX exchange rates. Off-chain services such as settlement processors and dashboards use it to read current rates and check staleness.
+
+### Standalone client
+
+```typescript
+import { FxOracleClient } from "@fluxapay/sdk";
+
+const oracleClient = new FxOracleClient({
+  network: "testnet",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  oracleContractId: "C...", // FX Oracle contract ID
+});
+
+async function queryRates() {
+  // Read the current rate for a currency pair
+  const rate = await oracleClient.getRate("USDCNGN");
+  console.log("Rate:", rate.rate, "decimals:", rate.decimals);
+
+  // Convert USDC to a settlement currency
+  const settlementAmount = await oracleClient.getSettlementAmount(
+    1_000_000n, // 1 USDC in stroops
+    "NGN",
+  );
+  console.log("Settlement amount:", settlementAmount);
+
+  // Check the staleness threshold (seconds)
+  const threshold = await oracleClient.getStalenessThreshold();
+  console.log("Staleness threshold:", threshold);
+}
+```
+
+### Via FluxapayClient
+
+Pass `oracleContractId` in `FluxapayConfig` to access the FX Oracle through the main client:
+
+```typescript
+import { FluxapayClient } from "@fluxapay/sdk";
+
+const client = new FluxapayClient({
+  network: "testnet",
+  contractId: "C...", // PaymentProcessor contract ID
+  oracleContractId: "C...", // FX Oracle contract ID
+});
+
+const oracle = client.fxOracle();
+const rate = await oracle.getRate("USDCNGN");
+```
+
+### Publishing rates (operator)
+
+```typescript
+// Publish a new rate (requires ORACLE role)
+await oracleClient.setRate(
+  "G...",        // operator address
+  "USDCNGN",     // pair
+  1_500_0000000n, // rate
+  7,             // decimals
+);
+
+// Update staleness threshold (requires ADMIN role)
+await oracleClient.setStalenessThreshold(
+  "G...",   // admin address
+  86_400n,  // 24 hours in seconds
+);
 ```
 
 ## License

--- a/sdk/src/contracts/fx-oracle.ts
+++ b/sdk/src/contracts/fx-oracle.ts
@@ -1,0 +1,206 @@
+import { NetworkProfileSwitcher, NetworkEnvironment } from "../network-profiles.js";
+import type { RateData } from "./fluxapay/src/index.js";
+
+export type { RateData };
+
+export interface FxOracleConfig {
+  network: NetworkEnvironment;
+  rpcUrl?: string;
+  oracleContractId: string;
+}
+
+export const FX_ORACLE_ERROR_MAP: Record<number, string> = {
+  1: "RateNotFound",
+  2: "RateStale",
+  3: "Unauthorized",
+};
+
+export class FxOracleError extends Error {
+  readonly code: number;
+  readonly contractErrorName: string;
+  readonly cause?: unknown;
+
+  constructor(code: number, contractErrorName: string, message?: string, cause?: unknown) {
+    super(message ?? contractErrorName);
+    this.name = `${contractErrorName}Error`;
+    this.code = code;
+    this.contractErrorName = contractErrorName;
+    this.cause = cause;
+  }
+}
+
+const HOST_ERROR_CODE_REGEX = /Error\(Contract,\s*#(\d+)\)/;
+
+function parseContractErrorCode(error: unknown): number | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const maybeCode = (error as { code?: unknown }).code;
+  if (typeof maybeCode === "number") {
+    return maybeCode;
+  }
+
+  const maybeMessage = (error as { message?: unknown }).message;
+  if (typeof maybeMessage === "string") {
+    const match = maybeMessage.match(HOST_ERROR_CODE_REGEX);
+    if (match && match[1]) {
+      return Number(match[1]);
+    }
+  }
+
+  const maybeResult = (error as { result?: unknown }).result;
+  if (typeof maybeResult === "string") {
+    const match = maybeResult.match(HOST_ERROR_CODE_REGEX);
+    if (match && match[1]) {
+      return Number(match[1]);
+    }
+  }
+
+  return null;
+}
+
+function toFxOracleError(error: unknown): FxOracleError {
+  const code = parseContractErrorCode(error);
+  if (code === null) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error("Unknown FX Oracle SDK error");
+  }
+
+  const contractErrorName = FX_ORACLE_ERROR_MAP[code] ?? "UnknownContractError";
+  return new FxOracleError(
+    code,
+    contractErrorName,
+    `${contractErrorName} (contract error #${code})`,
+    error,
+  );
+}
+
+async function withFxOracleContractError<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    throw toFxOracleError(error);
+  }
+}
+
+/**
+ * FxOracleClient provides a high-level interface for interacting with the FX Oracle contract.
+ * Supports rate publishing, settlement amount queries, and staleness threshold management.
+ */
+export class FxOracleClient {
+  private contract: any;
+  public networkSwitcher: NetworkProfileSwitcher;
+  private oracleContractId: string;
+  private rpcUrl: string;
+  private networkPassphrase: string;
+
+  constructor(config: FxOracleConfig) {
+    this.networkSwitcher = new NetworkProfileSwitcher(config.network);
+    const profile = this.networkSwitcher.getProfile();
+    this.rpcUrl = config.rpcUrl || profile.rpcUrl;
+    this.networkPassphrase = profile.networkPassphrase;
+    this.oracleContractId = config.oracleContractId;
+  }
+
+  private getContract(): any {
+    if (!this.contract) {
+      const { Client } = require("@stellar/stellar-sdk/contract");
+      this.contract = new Client({
+        networkPassphrase: this.networkPassphrase,
+        rpcUrl: this.rpcUrl,
+        contractId: this.oracleContractId,
+      });
+    }
+    return this.contract;
+  }
+
+  /**
+   * Switch the client to a different network environment.
+   * @param environment - The target network environment (e.g., 'testnet', 'mainnet')
+   * @param oracleContractId - Optional FX Oracle contract ID for the new network
+   */
+  public switchNetwork(environment: NetworkEnvironment, oracleContractId?: string): void {
+    this.networkSwitcher.switchEnvironment(environment);
+    const profile = this.networkSwitcher.getProfile();
+    this.rpcUrl = profile.rpcUrl;
+    this.networkPassphrase = profile.networkPassphrase;
+    if (oracleContractId) {
+      this.oracleContractId = oracleContractId;
+    }
+    this.contract = undefined;
+  }
+
+  /**
+   * Publish an exchange rate for a currency pair.
+   * @param operator - Address with the ORACLE role
+   * @param pair - Currency pair symbol (e.g., "USDCNGN")
+   * @param rate - Exchange rate as i128
+   * @param decimals - Decimal precision of the rate
+   */
+  async setRate(
+    operator: string,
+    pair: string,
+    rate: bigint,
+    decimals: number,
+  ) {
+    return withFxOracleContractError(() =>
+      this.getContract().set_rate({
+        operator,
+        pair,
+        rate,
+        decimals,
+      }),
+    );
+  }
+
+  /**
+   * Retrieve the current exchange rate for a currency pair.
+   * Rejects stale rates based on the configured staleness threshold.
+   * @param pair - Currency pair symbol (e.g., "USDCNGN")
+   */
+  async getRate(pair: string) {
+    return withFxOracleContractError(() =>
+      this.getContract().get_rate({ pair }),
+    );
+  }
+
+  /**
+   * Convert a USDC amount to the target settlement currency.
+   * @param usdcAmount - Amount in USDC stroops
+   * @param targetCurrency - Target currency symbol (e.g., "NGN")
+   */
+  async getSettlementAmount(usdcAmount: bigint, targetCurrency: string) {
+    return withFxOracleContractError(() =>
+      this.getContract().get_settlement_amount({
+        usdc_amount: usdcAmount,
+        target_currency: targetCurrency,
+      }),
+    );
+  }
+
+  /**
+   * Retrieve the current staleness threshold in seconds.
+   */
+  async getStalenessThreshold() {
+    return withFxOracleContractError(() =>
+      this.getContract().get_staleness_threshold(),
+    );
+  }
+
+  /**
+   * Update the staleness threshold for rate data.
+   * @param admin - Address with the ADMIN role
+   * @param threshold - New threshold in seconds
+   */
+  async setStalenessThreshold(admin: string, threshold: bigint) {
+    return withFxOracleContractError(() =>
+      this.getContract().set_staleness_threshold({
+        admin,
+        threshold,
+      }),
+    );
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -20,11 +20,14 @@ import {
   restoreFromOfflinePayload,
 } from "./offline-signer.js";
 import { NetworkProfileSwitcher, NetworkEnvironment, NetworkProfiles, NetworkProfile } from "./network-profiles.js";
+import { FxOracleClient } from "./contracts/fx-oracle.js";
 
 export interface FluxapayConfig {
   network: NetworkEnvironment;
   rpcUrl?: string;
   contractId: string;
+  /** FX Oracle contract ID for multi-currency rate queries. */
+  oracleContractId?: string;
 }
 
 export const FLUXAPAY_CONTRACT_ERROR_MAP: Record<number, string> = {
@@ -140,8 +143,11 @@ async function withMappedContractError<T>(operation: () => Promise<T>): Promise<
 export class FluxapayClient {
   public contract: ContractClient;
   public networkSwitcher: NetworkProfileSwitcher;
+  private fxOracleClient?: FxOracleClient;
+  private readonly config: FluxapayConfig;
 
   constructor(config: FluxapayConfig) {
+    this.config = config;
     this.networkSwitcher = new NetworkProfileSwitcher(config.network);
     
     // Override RPC URL if provided, otherwise use the default for the profile
@@ -152,6 +158,28 @@ export class FluxapayClient {
       rpcUrl: rpcUrl,
       contractId: config.contractId,
     });
+  }
+
+  /**
+   * Get an FX Oracle client when `oracleContractId` was provided in config.
+   */
+  fxOracle(): FxOracleClient {
+    if (!this.config.oracleContractId) {
+      throw new Error(
+        "oracleContractId is required in FluxapayConfig to use the FX Oracle client",
+      );
+    }
+
+    if (!this.fxOracleClient) {
+      const profile = this.networkSwitcher.getProfile();
+      this.fxOracleClient = new FxOracleClient({
+        network: profile.environment,
+        rpcUrl: this.config.rpcUrl || profile.rpcUrl,
+        oracleContractId: this.config.oracleContractId,
+      });
+    }
+
+    return this.fxOracleClient;
   }
 
   /**
@@ -168,6 +196,7 @@ export class FluxapayClient {
       rpcUrl: profile.rpcUrl,
       contractId: newContractId,
     });
+    this.fxOracleClient = undefined;
   }
 
   /**
@@ -289,3 +318,10 @@ export {
 
 export { RefundManagerClient, type RefundManagerConfig } from "./contracts/refund-manager.js";
 export { MerchantRegistryClient, type MerchantRegistryConfig } from "./contracts/merchant-registry.js";
+export {
+  FxOracleClient,
+  FxOracleError,
+  type FxOracleConfig,
+  type RateData,
+  FX_ORACLE_ERROR_MAP,
+} from "./contracts/fx-oracle.js";


### PR DESCRIPTION
## Summary

Adds a high-level `FxOracleClient` to the TypeScript SDK so off-chain services (settlement processors, dashboards) can query FX rates and manage staleness settings through typed methods.

- Implement `setRate`, `getRate`, `getSettlementAmount`, `getStalenessThreshold`, and `setStalenessThreshold` on `FxOracleClient`
- Export `RateData`, `FxOracleConfig`, `FxOracleError`, and `FX_ORACLE_ERROR_MAP` from `@fluxapay/sdk`
- Add optional `oracleContractId` to `FluxapayConfig` and expose `FluxapayClient.fxOracle()` for convenience
- Map FX Oracle contract errors separately (`RateNotFound`, `RateStale`, `Unauthorized`) to avoid collision with PaymentProcessor error codes
- Document FX Oracle usage in `sdk/README.md`

Closes #388

## Test plan

- [x] `npm run build` passes in `sdk/`
- [ ] Instantiate `FxOracleClient` with a testnet `oracleContractId`
- [ ] Call `getRate("USDCNGN")` and verify `RateData` fields (`pair`, `rate`, `decimals`, `updated_at`)
- [ ] Call `getSettlementAmount(1_000_000n, "NGN")` and verify returned amount
- [ ] Call `getStalenessThreshold()` and verify threshold value
- [ ] Call `setRate` / `setStalenessThreshold` with authorized operator/admin accounts
- [ ] Verify `FluxapayClient.fxOracle()` works when `oracleContractId` is provided in config
- [ ] Verify `FluxapayClient.fxOracle()` throws when `oracleContractId` is omitted