### PR TITLE
security(fx-oracle): Enforce hard staleness cap and ledger circuit breaker

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,3 +43,23 @@ A public bug bounty program is currently **in development**. Until then, we may 
 ## 🔐 Code Ownership
 
 Security-critical files, such as `access_control.rs` and the main `lib.rs` payment logic, require mandatory review from the security team as defined in our [`CODEOWNERS`](.github/CODEOWNERS) file.
+
+## 📊 FX Oracle Staleness Risk
+
+The `FXOracle` contract (`fluxapay/src/fx_oracle.rs`) provides exchange rates used for fiat settlement calculations. Rate freshness is validated using the Stellar ledger close time and ledger sequence number.
+
+### Threat Model
+
+| Risk | Description | Mitigation |
+| ---- | ----------- | ---------- |
+| **Ledger timestamp manipulation** | Stellar validators can influence ledger close time within a small window (~±a few seconds). | Hard 24-hour staleness cap (`MAX_RATE_AGE_SECS`) enforced regardless of admin-configured threshold. |
+| **Misconfigured threshold** | An admin could set an excessively long staleness threshold, allowing very old rates. | `effective_threshold = min(configured, MAX_RATE_AGE_SECS)` — hard cap always wins. |
+| **Compromised oracle key** | A malicious or delayed oracle operator could stop updating rates while settlement continues. | Ledger-sequence circuit breaker (`MAX_LEDGER_GAP`): if no rate update occurs within ~24 h of ledgers, `get_rate` and `get_settlement_amount` reject the rate and emit a `RATE/STALE_ALERT` event. |
+| **Timestamp-only false positives** | Legitimate rates could be rejected if ledger time drifts ahead of real time. | Accepted residual risk (~seconds). A dual timestamp+sequence AND-check is tracked as a follow-up (#384). |
+
+### Operational Guidance
+
+- Monitor `RATE/STALE_ALERT` events via the indexer or webhook pipeline.
+- Rotate oracle operator keys promptly if compromise is suspected.
+- Keep the off-chain rate feed latency well below the 24-hour hard cap.
+- Do not raise the admin staleness threshold above 24 hours expecting longer tolerance — the hard cap cannot be bypassed.

--- a/fluxapay/src/fx_oracle.rs
+++ b/fluxapay/src/fx_oracle.rs
@@ -108,7 +108,7 @@ impl FXOracle {
         let rate_data: RateData = env
             .storage()
             .persistent()
-            .get(&OracleDataKey::Rate(pair))
+            .get(&OracleDataKey::Rate(pair.clone()))
             .ok_or(FXOracleError::RateNotFound)?;
 
         Self::check_rate_freshness(&env, &rate_data, &pair)?;

--- a/fluxapay/src/fx_oracle.rs
+++ b/fluxapay/src/fx_oracle.rs
@@ -2,6 +2,12 @@ use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, 
 
 use crate::access_control::{role_admin, role_oracle, AccessControl};
 
+/// Maximum allowed age of a rate in seconds, regardless of admin-configured threshold.
+const MAX_RATE_AGE_SECS: u64 = 86_400; // 24 hours
+
+/// Maximum ledger sequence gap since last rate update (~24 h at ~5 s/ledger).
+const MAX_LEDGER_GAP: u32 = 17_280;
+
 #[contract]
 pub struct FXOracle;
 
@@ -12,6 +18,7 @@ pub struct RateData {
     pub rate: i128,
     pub decimals: u32,
     pub updated_at: u64,
+    pub updated_sequence: u32,
 }
 
 #[contracterror]
@@ -81,6 +88,7 @@ impl FXOracle {
             rate,
             decimals,
             updated_at: env.ledger().timestamp(),
+            updated_sequence: env.ledger().sequence(),
         };
 
         env.storage()
@@ -103,17 +111,54 @@ impl FXOracle {
             .get(&OracleDataKey::Rate(pair))
             .ok_or(FXOracleError::RateNotFound)?;
 
-        let threshold: u64 = env
+        Self::check_rate_freshness(&env, &rate_data, &pair)?;
+
+        Ok(rate_data)
+    }
+
+    // SECURITY: Rate freshness relies on ledger wall-clock time (`env.ledger().timestamp()`),
+    // which Stellar validators can influence within a small window (~±a few seconds).
+    // A compromised oracle key or delayed off-chain feed could also leave stale rates in
+    // storage. Mitigations enforced here:
+    //   1. Hard cap (`MAX_RATE_AGE_SECS`) — rates older than 24 h are always rejected,
+    //      even if the admin-configured threshold is higher.
+    //   2. Ledger-sequence circuit breaker (`MAX_LEDGER_GAP`) — if no rate update has
+    //      occurred within the last N ledgers, settlement is blocked and a STALE_ALERT
+    //      event is emitted for off-chain monitoring.
+    // Accepted residual risk: timestamp drift within the validator window may delay or
+    // accelerate staleness by a few seconds. A dual timestamp+sequence AND-check (reject
+    // only when both conditions hold) is tracked as a follow-up to reduce false positives.
+    fn check_rate_freshness(
+        env: &Env,
+        rate_data: &RateData,
+        pair: &Symbol,
+    ) -> Result<(), FXOracleError> {
+        let configured_threshold: u64 = env
             .storage()
             .instance()
             .get(&OracleDataKey::StalenessThreshold)
-            .unwrap_or(86400);
+            .unwrap_or(MAX_RATE_AGE_SECS);
 
-        if env.ledger().timestamp() > rate_data.updated_at + threshold {
+        let effective_threshold = configured_threshold.min(MAX_RATE_AGE_SECS);
+
+        let now = env.ledger().timestamp();
+        if now > rate_data.updated_at.saturating_add(effective_threshold) {
             return Err(FXOracleError::RateStale);
         }
 
-        Ok(rate_data)
+        let ledger_gap = env
+            .ledger()
+            .sequence()
+            .saturating_sub(rate_data.updated_sequence);
+        if ledger_gap > MAX_LEDGER_GAP {
+            env.events().publish(
+                (Symbol::new(env, "RATE"), Symbol::new(env, "STALE_ALERT")),
+                pair.clone(),
+            );
+            return Err(FXOracleError::RateStale);
+        }
+
+        Ok(())
     }
 
     pub fn get_settlement_amount(
@@ -135,7 +180,7 @@ impl FXOracle {
         env.storage()
             .instance()
             .get(&OracleDataKey::StalenessThreshold)
-            .unwrap_or(86400)
+            .unwrap_or(MAX_RATE_AGE_SECS)
     }
 
     /// Upgrade the contract WASM.

--- a/fluxapay/src/fx_oracle_test.rs
+++ b/fluxapay/src/fx_oracle_test.rs
@@ -68,6 +68,48 @@ fn test_staleness_check() {
 }
 
 #[test]
+fn test_hard_staleness_cap_despite_high_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_oracle(&env);
+
+    let oracle = Address::generate(&env);
+    client.oracle_grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+
+    // Admin sets a permissive 7-day threshold; hard cap still applies at 24 h.
+    client.set_staleness_threshold(&admin, &(7 * 86_400));
+
+    let pair = Symbol::new(&env, "USDC_NGN");
+    client.set_rate(&oracle, &pair, &1500i128, &0);
+
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 25 * 3600);
+
+    let result = client.try_get_rate(&pair);
+    assert_eq!(result, Err(Ok(FXOracleError::RateStale)));
+}
+
+#[test]
+fn test_circuit_breaker_rejects_rate_by_ledger_gap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_oracle(&env);
+
+    let oracle = Address::generate(&env);
+    client.oracle_grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+
+    let pair = Symbol::new(&env, "USDC_NGN");
+    client.set_rate(&oracle, &pair, &1500i128, &0);
+
+    let seq_at_update = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq_at_update + 17_281);
+
+    let result = client.try_get_rate(&pair);
+    assert_eq!(result, Err(Ok(FXOracleError::RateStale)));
+}
+
+#[test]
 fn test_settlement_amount_calculation() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

Closes #384.

Mitigates FX Oracle timestamp-based staleness risks by enforcing a hard 24-hour rate age cap, adding a ledger-sequence circuit breaker, and documenting accepted residual risk.

- **Hard staleness cap** — `effective_threshold = min(configured, MAX_RATE_AGE_SECS)` so rates older than 24 hours are always rejected, even if the admin sets a higher threshold.
- **Ledger-sequence circuit breaker** — `RateData` now stores `updated_sequence`; if the ledger gap exceeds `MAX_LEDGER_GAP` (~24 h at ~5 s/ledger), `get_rate` / `get_settlement_amount` return `RateStale` and emit a `RATE/STALE_ALERT` event for off-chain monitoring.
- **Security documentation** — `// SECURITY:` comment in `fx_oracle.rs` and a new **FX Oracle Staleness Risk** section in `SECURITY.md` covering threat model and operational guidance.
- **Tests** — verify hard cap overrides a permissive admin threshold, and that the circuit breaker rejects rates by ledger gap.

### Follow-up (optional, tracked in #384)

Dual timestamp + ledger-sequence AND-check to reduce false positives from validator timestamp drift (~±a few seconds).

## Test plan

- [ ] `cargo test fx_oracle_test` — all FX Oracle tests pass
- [ ] `test_hard_staleness_cap_despite_high_threshold` — 7-day admin threshold still rejects a 25-hour-old rate
- [ ] `test_circuit_breaker_rejects_rate_by_ledger_gap` — rate rejected after `MAX_LEDGER_GAP + 1` ledgers without update
- [ ] Existing `test_staleness_check` still passes with default 24 h threshold