### PR TITLE
feat(sdk): add npm publish workflow and configure package for scoped release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,10 @@ jobs:
         working-directory: sdk
         run: npm run build
 
+      - name: Test SDK
+        working-directory: sdk
+        run: npm test
+
   # Final job: Report overall status
   ci-success:
     name: CI Success

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -1,0 +1,57 @@
+name: SDK Release
+
+on:
+  push:
+    tags:
+      - "sdk/v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @fluxapay/sdk
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION="${GITHUB_REF_NAME#sdk/v}"
+          if [ -z "$VERSION" ]; then
+            echo "Tag must follow the format sdk/v<semver> (e.g. sdk/v0.1.0)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing @fluxapay/sdk@$VERSION"
+
+      - name: Sync package version with tag
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: sdk/package-lock.json
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build SDK
+        run: npm run build
+
+      - name: Test SDK
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@ Fluxapay is a payment gateway on the Stellar blockchain that enables merchants t
 
 FluxaPay bridges the gap between crypto payments and real-world commerce—making stablecoin payments as easy to integrate as Stripe.
 
+## TypeScript SDK
+
+[![npm version](https://img.shields.io/npm/v/@fluxapay/sdk.svg)](https://www.npmjs.com/package/@fluxapay/sdk)
+
+Install the official SDK from npm:
+
+```bash
+npm install @fluxapay/sdk
+```
+
+See [sdk/README.md](sdk/README.md) for usage examples and [sdk/CHANGELOG.md](sdk/CHANGELOG.md) for release notes.
+
 ## CI/CD
 
 [![CI](https://github.com/MetroLogic/fluxapay_contract/actions/workflows/ci.yml/badge.svg)](https://github.com/MetroLogic/fluxapay_contract/actions/workflows/ci.yml)

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to `@fluxapay/sdk` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial npm publish workflow (`sdk/v*` tags) and scoped package configuration.
+
+## [0.1.0] - 2026-06-25
+
+### Added
+- `FluxapayClient` high-level wrapper for payment, refund, and merchant contract calls.
+- `RefundManagerClient` and `MerchantRegistryClient` for dedicated contract interactions.
+- Typed contract models (`Merchant`, `PaymentCharge`, `Refund`, `Dispute`, etc.).
+- Network profile presets for testnet and mainnet.
+- Offline/hardware wallet signing helpers via `FluxapayOfflineSigner`.
+- Contract error mapping with `FluxapayError` and `FLUXAPAY_CONTRACT_ERROR_MAP`.
+
+[Unreleased]: https://github.com/MetroLogic/fluxapay_contract/compare/sdk/v0.1.0...HEAD
+[0.1.0]: https://github.com/MetroLogic/fluxapay_contract/releases/tag/sdk/v0.1.0

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -8,6 +8,10 @@ Official TypeScript SDK for interacting with FluxaPay's Soroban smart contracts 
 npm install @fluxapay/sdk
 ```
 
+## Release Notes
+
+See [CHANGELOG.md](./CHANGELOG.md) for version history.
+
 ## Quick Start
 
 ```typescript
@@ -131,3 +135,14 @@ async function manageMerchant() {
 ## License
 
 MIT
+
+## Publishing
+
+Releases are published to npm when a version tag is pushed:
+
+```bash
+git tag sdk/v0.1.0
+git push origin sdk/v0.1.0
+```
+
+The [SDK Release](https://github.com/MetroLogic/fluxapay_contract/actions/workflows/sdk-release.yml) workflow builds, tests, and publishes `@fluxapay/sdk`. Requires `NPM_TOKEN` in GitHub repository secrets (npm automation token with publish access to the `@fluxapay` scope).

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -5,11 +5,23 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MetroLogic/fluxapay_contract.git",
+    "directory": "sdk"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "generate": "bash ../scripts/generate-sdk.sh",
     "generate:build": "npm run generate && npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --input-type=module -e \"import { FluxapayClient, RefundManagerClient, MerchantRegistryClient } from './dist/index.js'; if (typeof FluxapayClient !== 'function' || typeof RefundManagerClient !== 'function' || typeof MerchantRegistryClient !== 'function') { throw new Error('Missing SDK exports'); }\"",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Closes #389

Adds automated npm publishing for `@fluxapay/sdk` so integrators can install from npm instead of cloning the repo.

- Configure `sdk/package.json` for scoped public publish (`publishConfig`, `files`, `repository`)
- Add `.github/workflows/sdk-release.yml` triggered on `sdk/v*` tags (install → build → test → publish)
- Add `sdk/CHANGELOG.md` for SDK release notes
- Update root README with npm version badge and `npm install @fluxapay/sdk`
- Run SDK smoke tests in CI (`sdk-check` job)

## Acceptance criteria

- [x] `sdk/package.json` has correct `name`, `version`, `main`, `types`, and `publishConfig`
- [x] `sdk-release.yml` exists and publishes on `sdk/v*` tags
- [x] `npm pack` produces a tarball with only `dist/` and type definitions (plus `README.md` / `package.json`)
- [x] SDK changelog exists at `sdk/CHANGELOG.md`
- [x] README updated with `npm install @fluxapay/sdk`

## Release workflow

1. Add `NPM_TOKEN` (npm automation token with publish access to `@fluxapay`) to GitHub repository secrets
2. Tag and push:
   ```bash
   git tag sdk/v0.1.0
   git push origin sdk/v0.1.0