### PR TITLE
doc(security): gate mainnet cd on external audit completion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 fluxapay/src/access_control.rs   @MetroLogic/security-reviewers
 fluxapay/src/lib.rs              @MetroLogic/security-reviewers
 fluxapay/src/merchant_registry.rs @MetroLogic/security-reviewers
+audits/                            @MetroLogic/security-reviewers
+SECURITY.md                        @MetroLogic/security-reviewers
 
 # Catch-all for other files
 *                                @MetroLogic/core-maintainers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,12 +73,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-deploy-${{ inputs.environment_name }}-
 
+      - name: Verify external audit completion (Production Only)
+        if: inputs.is_production
+        run: |
+          echo "=== EXTERNAL AUDIT GATE (MAINNET) ==="
+          STATUS_FILE="audits/external-audit-status.json"
+          if [ ! -f "$STATUS_FILE" ]; then
+            echo "❌ BLOCKED: $STATUS_FILE not found."
+            echo "   Mainnet deployment requires a completed external audit (#381)."
+            echo "   See SECURITY.md and audits/SCOPE.md."
+            exit 1
+          fi
+          audit_complete=$(jq -r '.external_audit.audit_complete' "$STATUS_FILE")
+          critical_resolved=$(jq -r '.external_audit.critical_findings_resolved' "$STATUS_FILE")
+          high_resolved=$(jq -r '.external_audit.high_findings_resolved' "$STATUS_FILE")
+          auditor=$(jq -r '.external_audit.auditor // "not assigned"' "$STATUS_FILE")
+          report_url=$(jq -r '.external_audit.report_url // "not published"' "$STATUS_FILE")
+          echo "Auditor:              $auditor"
+          echo "Audit complete:       $audit_complete"
+          echo "Critical resolved:    $critical_resolved"
+          echo "High resolved:        $high_resolved"
+          echo "Report URL:           $report_url"
+          if [ "$audit_complete" != "true" ] || \
+             [ "$critical_resolved" != "true" ] || \
+             [ "$high_resolved" != "true" ]; then
+            echo ""
+            echo "❌ BLOCKED: External audit requirements not met."
+            echo "   Update $STATUS_FILE after audit completion and remediation."
+            echo "   Tracking issue: #381"
+            exit 1
+          fi
+          echo "✓ External audit gate passed"
+
       - name: Pre-deployment Checklist (Production Only)
         if: inputs.is_production
         run: |
           echo "=== PRE-DEPLOYMENT CHECKLIST FOR PRODUCTION ==="
           echo "✓ Tests pass: Verified by CI pipeline"
-          echo "✓ Audit complete: Check audit reports in /audits directory"
+          echo "✓ External audit: Verified by audit gate above"
           echo "✓ Changelog updated: Verify CHANGELOG.md has latest changes"
           echo "✓ Security review: Ensure no critical vulnerabilities"
           echo "✓ Code review: At least 2 team members approved PR"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-FluxaPay takes the security of our smart contracts and user funds (USDC) extremely seriously. This document outlines our vulnerability disclosure policy and current audit status.
+FluxaPay takes the security of our smart contracts and user funds (USDC) extremely seriously. This document outlines our vulnerability disclosure policy, audit status, and mainnet readiness requirements.
 
 ## 🛡️ Vulnerability Disclosure Policy
 
@@ -28,17 +28,42 @@ To help us prioritize and address your report, please include:
 
 ## 💰 Bug Bounty Program
 
-A public bug bounty program is currently **in development**. Until then, we may provide discretionary rewards for high-impact, responsibly disclosed vulnerabilities.
+A public bug bounty program is **planned for launch after the external audit completes** (issue #381). Until then, we may provide discretionary rewards for high-impact, responsibly disclosed vulnerabilities.
+
+| Milestone | Status |
+| --------- | ------ |
+| External audit complete | Pending |
+| Bug bounty platform selected | Pending |
+| Public program launched | Pending |
 
 ## 🔍 Audit Status
 
 | Audit Date | Auditor  | Scope           | Status               | Report Link        |
 | ---------- | -------- | --------------- | -------------------- | ------------------ |
 | 2026-03-27 | Internal | All Contracts   | Completed (Internal) | N/A                |
-| TBD        | External | Mainnet Release | Upcoming             | [Link Placeholder] |
+| TBD        | External | Mainnet Release | **In Progress**      | [Link Placeholder] |
+
+### External Audit Engagement (issue #381)
+
+An independent external audit is **required before mainnet deployment**. Current status:
+
+| Milestone | Status |
+| --------- | ------ |
+| Audit firm selection | In progress |
+| Engagement letter signed | Pending |
+| [Audit scope document](audits/SCOPE.md) | Draft complete |
+| Audit execution | Not started |
+| Critical/High findings resolved | Pending |
+| Report published | Pending |
+
+**Candidate auditors** (under evaluation): OtterSec, Trail of Bits, Halborn, CertiK.
+
+**Scope:** PaymentProcessor, RefundManager, FXOracle, MerchantRegistry, PaymentLinkManager — see [audits/SCOPE.md](audits/SCOPE.md) for full details.
+
+**Mainnet gate:** Production deployments are blocked by CI until `audits/external-audit-status.json` confirms audit completion and remediation of all Critical/High findings. See [DEPLOYMENT.md](DEPLOYMENT.md).
 
 > [!IMPORTANT]
-> This project is currently in **active development**. Use with caution and only on Testnet for now.
+> This project is currently in **active development**. Use with caution and only on Testnet for now. **Do not deploy to mainnet until the external audit is complete.**
 
 ## 🔐 Code Ownership
 

--- a/audits/SCOPE.md
+++ b/audits/SCOPE.md
@@ -1,0 +1,132 @@
+# FluxaPay External Smart Contract Audit — Scope Document
+
+**Version:** 1.0  
+**Status:** Draft (pending auditor engagement)  
+**Target network:** Stellar Mainnet  
+**Issue tracker:** #381
+
+## Executive Summary
+
+FluxaPay is a Soroban-based payment protocol that handles real USDC transfers, role-based access control, refunds, disputes, and merchant KYC tiering. This document defines the scope for an independent external security audit required before mainnet deployment.
+
+## In-Scope Contracts
+
+All five deployable contracts in the `fluxapay` workspace:
+
+| Contract | Source | Responsibility |
+| -------- | ------ | -------------- |
+| **PaymentProcessor** | `fluxapay/src/lib.rs` | Payment creation, settlement, fee splits, disputes, subscriptions, cross-contract orchestration |
+| **RefundManager** | `fluxapay/src/lib.rs` | Refund lifecycle, cooldown enforcement, collaborative settlement, DEX-routed refunds |
+| **FXOracle** | `fluxapay/src/fx_oracle.rs` | Exchange rate storage, staleness checks, oracle role management |
+| **MerchantRegistry** | `fluxapay/src/merchant_registry.rs` | Merchant registration, KYC tiers, volume caps, tier auto-upgrades |
+| **PaymentLinkManager** | `fluxapay/src/payment_link.rs` | Payment link creation, usage tracking, multi-currency fiat config |
+
+## In-Scope Shared Modules
+
+These modules are compiled into the above contracts and must be reviewed as part of cross-contract security analysis:
+
+| Module | Source | Relevance |
+| ------ | ------ | --------- |
+| **AccessControl** | `fluxapay/src/access_control.rs` | Role grants/revocations, admin transfer proposals, recovery keys, revocation cooldowns |
+| **MerchantAuth** | `fluxapay/src/merchant_auth.rs` | Merchant authorization and pre-auth flows |
+| **DexRouter** | `fluxapay/src/dex_router.rs` | Token swap routing for `swap_and_pay` and swap-based refunds |
+| **AccountAbstraction** | `fluxapay/src/account_abstraction.rs` | Account abstraction helpers used in payment flows |
+| **Stream** | `fluxapay/src/stream.rs` | Streaming payment logic |
+| **Utils** | `fluxapay/src/utils.rs` | Shared validation and helper functions |
+
+## Security Focus Areas
+
+The auditor should prioritize the following threat categories:
+
+### 1. Access Control & Privilege Escalation
+
+- Role grant/revoke flows (`ADMIN`, `ORACLE`, `MERCHANT`, `SETTLEMENT_OPERATOR`, `ARBITRATOR`)
+- Admin transfer proposals, multi-sig thresholds, and recovery key mechanisms
+- Revocation cooldown bypass attempts
+- Unauthorized contract initialization or re-initialization
+
+### 2. Fund Safety & Token Handling
+
+- USDC (and other SAC token) transfer correctness — amount, recipient, reentrancy
+- Fee split arithmetic (treasury, developer, merchant) and rounding
+- Refund routing: direct vs. DEX swap paths
+- Dispute bond escrow and release conditions
+- Subscription retry and cancellation fund handling
+
+### 3. Business Logic & State Machine Integrity
+
+- Payment status transitions (`PENDING` → `SETTLED` → `DISPUTED` → `REFUNDED`)
+- Refund cooldown (`REFUND_COOLDOWN_SECS`) and expiry enforcement
+- Idempotency key handling and duplicate payment prevention
+- Rate limiting (per-merchant, per-payer, create-payment window)
+- KYC tier volume caps and automatic tier upgrades
+- Arbitration voting threshold (`ARBITRATOR_VOTING_THRESHOLD`)
+
+### 4. Oracle & Price Manipulation
+
+- FX rate staleness checks and stale-rate rejection
+- Oracle role authorization for rate updates
+- Multi-currency payment link fiat config validation
+- DEX swap slippage and path manipulation in `swap_and_pay`
+
+### 5. Cross-Contract Interactions
+
+- PaymentProcessor → MerchantRegistry verification calls
+- PaymentProcessor → RefundManager refund creation/processing
+- PaymentProcessor → FXOracle rate lookups
+- PaymentProcessor → PaymentLinkManager link usage
+- RefundManager → DexRouter swap execution
+- Reentrancy locks across inter-contract call boundaries
+
+### 6. Denial of Service & Resource Exhaustion
+
+- Storage TTL bump logic and ledger resource consumption
+- Unbounded storage growth vectors
+- Payment spam mitigation (`CREATE_PAYMENT_MAX_PER_WINDOW`)
+- Pause/unpause emergency controls
+
+## Out of Scope
+
+- Stellar/Soroban platform vulnerabilities
+- Front-end applications and SDK client code (`sdk/`, `bindings/`)
+- Off-chain indexer (`indexer/`)
+- Third-party DEX protocol internals (DexRouter interface only)
+- Infrastructure, CI/CD, and deployment scripts (except where they affect on-chain security assumptions)
+- Economic/game-theoretic analysis of fee parameters (unless exploitable on-chain)
+
+## Deliverables
+
+1. **Full audit report** with severity-classified findings (Critical, High, Medium, Low, Informational)
+2. **Remediation verification** re-review of all Critical and High findings
+3. **Executive summary** suitable for public disclosure
+4. **Test coverage assessment** against the in-scope attack surface
+
+## Acceptance Criteria
+
+Per issue #381:
+
+- [ ] Engagement letter signed with a reputable Soroban/Rust auditing firm
+- [ ] All Critical and High severity findings resolved before mainnet
+- [ ] Audit report (or public summary) published and linked from `SECURITY.md`
+- [ ] `audits/external-audit-status.json` updated to reflect completion
+- [ ] Bug bounty program launched post-audit (referenced in `SECURITY.md`)
+
+## Candidate Auditors
+
+The following firms have Soroban/Stellar or Rust smart contract audit experience and are under evaluation:
+
+| Firm | Notes |
+| ---- | ----- |
+| [OtterSec](https://osec.io/) | Stellar ecosystem experience |
+| [Trail of Bits](https://www.trailofbits.com/) | Rust/LLVM security expertise |
+| [Halborn](https://www.halborn.com/) | Blockchain audit practice |
+| [CertiK](https://www.certik.com/) | Formal verification and audit services |
+
+> Final auditor selection is pending engagement negotiations. Update `audits/external-audit-status.json` when a firm is selected.
+
+## Repository References
+
+- Architecture overview: [`docs/architecture.md`](../docs/architecture.md)
+- Security policy: [`SECURITY.md`](../SECURITY.md)
+- Deployment checklist: [`DEPLOYMENT.md`](../DEPLOYMENT.md)
+- Audit status (machine-readable): [`external-audit-status.json`](./external-audit-status.json)

--- a/audits/external-audit-status.json
+++ b/audits/external-audit-status.json
@@ -1,0 +1,17 @@
+{
+  "external_audit": {
+    "status": "pending_engagement",
+    "auditor": null,
+    "engagement_signed": false,
+    "scope_document": "audits/SCOPE.md",
+    "audit_start_date": null,
+    "audit_complete": false,
+    "report_published": false,
+    "report_url": null,
+    "critical_findings_resolved": false,
+    "high_findings_resolved": false,
+    "bug_bounty_launched": false,
+    "bug_bounty_url": null,
+    "notes": "Update this file when engagement is signed and again when the audit completes. Mainnet CD is blocked until audit_complete, critical_findings_resolved, and high_findings_resolved are all true."
+  }
+}


### PR DESCRIPTION
## Summary

Closes #381 (partial — infrastructure and tracking; auditor engagement remains a business action).

- Adds an external audit scope document covering all five mainnet contracts (PaymentProcessor, RefundManager, FXOracle, MerchantRegistry, PaymentLinkManager) plus shared security-critical modules
- Introduces `audits/external-audit-status.json` as the machine-readable source of truth for audit milestones
- Updates `SECURITY.md` with engagement tracking, candidate auditors, bug bounty timeline, and mainnet readiness requirements
- Enforces a hard mainnet deployment gate in CD: production deploys fail unless external audit is complete and all Critical/High findings are resolved
- Adds `audits/` and `SECURITY.md` to `CODEOWNERS` for mandatory security team review

## Changes

| File | Change |
|------|--------|
| `audits/SCOPE.md` | Draft audit scope for external firm engagement |
| `audits/external-audit-status.json` | Tracks engagement, completion, remediation, and bug bounty status |
| `SECURITY.md` | External audit marked in progress; links scope doc and explains mainnet gate |
| `.github/workflows/deploy.yml` | New production-only step that blocks deploy when audit flags are false |
| `.github/CODEOWNERS` | Security reviewers own `audits/` and `SECURITY.md` |

## Acceptance criteria

- [x] Audit scope document created covering all five contracts
- [x] Mainnet CD pipeline gated (manual approval + audit completion check)
- [x] `SECURITY.md` updated with engagement details and timeline
- [ ] Audit firm selected and engagement letter signed *(pending business action)*
- [ ] All critical/high findings resolved *(post-audit)*
- [ ] Audit report published and linked from `SECURITY.md` *(post-audit)*
- [ ] Bug bounty program launched *(post-audit)*

## Test plan

- [ ] Confirm testnet dev/staging deploys are unaffected (no audit gate on non-production)
- [ ] Trigger a production workflow dispatch and verify the audit gate step fails with a clear message while `external-audit-status.json` has `audit_complete: false`
- [ ] Review `audits/SCOPE.md` for completeness against current contract surface area
- [ ] Verify `SECURITY.md` renders correctly on GitHub (tables, callouts, links)