### PR TITLE
chore: remove committed actionlint binary and install via CI action i…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,11 +413,23 @@ jobs:
         working-directory: sdk
         run: npm test
 
+  # Job 7: Lint GitHub Actions workflows with actionlint
+  actionlint:
+    name: Lint GitHub Actions (actionlint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+
   # Final job: Report overall status
   ci-success:
     name: CI Success
     if: ${{ always() }}
-    needs: [format, lint, security-audit, build, test, coverage, sdk-check]
+    needs: [format, lint, security-audit, build, test, coverage, sdk-check, actionlint]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -429,7 +441,8 @@ jobs:
              [[ "${{ needs.build.result }}" == "success" ]] && \
              [[ "${{ needs.test.result }}" == "success" ]] && \
              [[ "${{ needs.coverage.result }}" == "success" ]] && \
-             [[ "${{ needs.sdk-check.result }}" == "success" ]]; then
+             [[ "${{ needs.sdk-check.result }}" == "success" ]] && \
+             [[ "${{ needs.actionlint.result }}" == "success" ]]; then
             echo "✅ All CI checks passed!"
             exit 0
           else

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ fluxapay/test_snapshots
 node_modules
 dist
 package-lock.json
+
+# actionlint binary (installed at CI runtime via rhysd/actionlint action)
+/actionlint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,25 @@ Or via Makefile:
 cd fluxapay && make fmt && cargo clippy --all-targets --all-features
 ```
 
----
+### Linting GitHub Actions Workflows (actionlint)
+
+We use [actionlint](https://github.com/rhysd/actionlint) to statically check all `.github/workflows/*.yml` files.
+CI runs it automatically via the `rhysd/actionlint@v1` action — **do not commit the binary to the repo**.
+
+To run it locally, install the tool for your platform and execute it from the repo root:
+
+```bash
+# macOS (Homebrew)
+brew install actionlint
+
+# Linux (go install)
+go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+# Run against all workflows
+actionlint
+```
+
+
 
 ## 5. Branch Naming Conventions
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -250,6 +250,93 @@ const oracle = client.fxOracle();
 const rate = await oracle.getRate("USDCNGN");
 ```
 
+## Payment Links (FluxapayClient)
+
+Payment links let merchants share a reusable URL that payers can settle against. Pass `paymentLinkContractId` in config to enable these methods.
+
+### Create a payment link
+
+```typescript
+import { FluxapayClient } from "@fluxapay/sdk";
+
+const client = new FluxapayClient({
+  network: "testnet",
+  contractId: "C...",
+  paymentLinkContractId: "C...", // PaymentLinkManager contract ID
+});
+
+// Fixed-amount link
+const linkId = await client.createLink({
+  merchant: "G...",
+  amount: 5_000_000n, // 0.5 USDC (7 decimals)
+  usdcToken: "C...",
+  metadata: { product: "Coffee", ref: "order_42" }, // optional
+});
+console.log("Link created:", linkId);
+
+// Open-amount link (payer sets the amount)
+const openLinkId = await client.createLink({
+  merchant: "G...",
+  usdcToken: "C...",
+});
+```
+
+### Use a payment link
+
+```typescript
+await client.useLink(
+  "G...",        // payer address
+  linkId,        // link ID returned by createLink
+  5_000_000n,    // amount in stroops
+  "C...",        // USDC token contract address
+);
+```
+
+### Retrieve and verify links
+
+```typescript
+// Fetch a single link
+const link = await client.getLink(linkId);
+console.log("Link active:", link.active);
+console.log("Merchant:", link.merchant);
+console.log("Metadata:", link.metadata);
+
+// Batch-verify multiple links (returns only active link IDs)
+const activeLinkIds = await client.verifyBatch([linkId, openLinkId, "C_other..."]);
+console.log("Active links:", activeLinkIds);
+```
+
+### Deactivate a link
+
+```typescript
+// Only the merchant that created the link can deactivate it
+await client.deactivateLink("G...", linkId);
+```
+
+### Standalone PaymentLinkManagerClient
+
+```typescript
+import { PaymentLinkManagerClient } from "@fluxapay/sdk";
+
+const linkClient = new PaymentLinkManagerClient({
+  network: "testnet",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  contractId: "C...", // PaymentLinkManager contract ID
+});
+
+const linkId = await linkClient.createLink({
+  merchant: "G...",
+  amount: 10_000_000n,
+  usdcToken: "C...",
+  metadata: { item: "Widget" },
+});
+
+const link = await linkClient.getLink(linkId);
+await linkClient.useLink("G_payer...", linkId, 10_000_000n, "C...");
+await linkClient.deactivateLink("G_merchant...", linkId);
+const active = await linkClient.verifyBatch([linkId]);
+```
+
 ## License
 
 MIT

--- a/sdk/src/contracts/payment-link-manager.ts
+++ b/sdk/src/contracts/payment-link-manager.ts
@@ -1,0 +1,167 @@
+import { NetworkProfileSwitcher, NetworkEnvironment } from "../network-profiles.js";
+import { withMappedContractError } from "../index.js";
+
+export interface PaymentLinkManagerConfig {
+  network: NetworkEnvironment;
+  rpcUrl?: string;
+  contractId: string;
+}
+
+/**
+ * Represents a payment link stored on-chain in the PaymentLinkManager contract.
+ */
+export interface PaymentLink {
+  /** Unique link identifier */
+  link_id: string;
+  /** Stellar address of the merchant that created the link */
+  merchant: string;
+  /** Optional fixed amount in stroops; undefined means the payer supplies the amount */
+  amount?: bigint;
+  /** Whether this link is currently active */
+  active: boolean;
+  /** USDC token contract address */
+  usdc_token: string;
+  /** Arbitrary key/value metadata attached to the link */
+  metadata?: Record<string, string>;
+}
+
+/**
+ * Parameters for creating a new payment link.
+ */
+export interface CreateLinkParams {
+  /** The merchant's Stellar address */
+  merchant: string;
+  /** Optional fixed amount in stroops */
+  amount?: bigint;
+  /** USDC token contract address */
+  usdcToken: string;
+  /** Arbitrary metadata (e.g. product info, order reference) */
+  metadata?: Record<string, string>;
+}
+
+/**
+ * PaymentLinkManagerClient provides a high-level interface for interacting
+ * with the PaymentLinkManager Soroban contract.
+ */
+export class PaymentLinkManagerClient {
+  private contract: any;
+  public networkSwitcher: NetworkProfileSwitcher;
+  private contractId: string;
+  private rpcUrl: string;
+  private networkPassphrase: string;
+
+  constructor(config: PaymentLinkManagerConfig) {
+    this.networkSwitcher = new NetworkProfileSwitcher(config.network);
+    const profile = this.networkSwitcher.getProfile();
+    this.rpcUrl = config.rpcUrl || profile.rpcUrl;
+    this.networkPassphrase = profile.networkPassphrase;
+    this.contractId = config.contractId;
+  }
+
+  private getContract(): any {
+    if (!this.contract) {
+      const { Client } = require("@stellar/stellar-sdk/contract");
+      this.contract = new Client({
+        networkPassphrase: this.networkPassphrase,
+        rpcUrl: this.rpcUrl,
+        contractId: this.contractId,
+      });
+    }
+    return this.contract;
+  }
+
+  /**
+   * Switch the client to a different network environment.
+   * @param environment - Target network environment
+   * @param contractId - Optional new contract ID
+   */
+  public switchNetwork(environment: NetworkEnvironment, contractId?: string): void {
+    this.networkSwitcher.switchEnvironment(environment);
+    const profile = this.networkSwitcher.getProfile();
+    this.rpcUrl = profile.rpcUrl;
+    this.networkPassphrase = profile.networkPassphrase;
+    if (contractId) {
+      this.contractId = contractId;
+    }
+    this.contract = undefined;
+  }
+
+  /**
+   * Create a new payment link.
+   * @param params - Link creation parameters
+   * @returns A promise resolving to the new link ID
+   */
+  async createLink(params: CreateLinkParams): Promise<string> {
+    return withMappedContractError(() =>
+      this.getContract().create_link({
+        merchant: params.merchant,
+        amount: params.amount,
+        usdc_token: params.usdcToken,
+        metadata: params.metadata,
+      }),
+    );
+  }
+
+  /**
+   * Use a payment link to initiate a payment.
+   * @param payer - The payer's Stellar address
+   * @param linkId - The payment link ID
+   * @param amount - The amount to pay in stroops
+   * @param usdcToken - The USDC token contract address
+   */
+  async useLink(
+    payer: string,
+    linkId: string,
+    amount: bigint,
+    usdcToken: string,
+  ): Promise<void> {
+    return withMappedContractError(() =>
+      this.getContract().use_link({
+        payer,
+        link_id: linkId,
+        amount,
+        usdc_token: usdcToken,
+      }),
+    );
+  }
+
+  /**
+   * Deactivate a payment link (merchant only).
+   * @param merchant - The merchant's Stellar address
+   * @param linkId - The payment link ID to deactivate
+   */
+  async deactivateLink(merchant: string, linkId: string): Promise<void> {
+    return withMappedContractError(() =>
+      this.getContract().deactivate_link({
+        merchant,
+        link_id: linkId,
+      }),
+    );
+  }
+
+  /**
+   * Retrieve details of a specific payment link.
+   * @param linkId - The payment link ID
+   * @returns A promise resolving to the PaymentLink details
+   */
+  async getLink(linkId: string): Promise<PaymentLink> {
+    return withMappedContractError(() =>
+      this.getContract().get_link({
+        link_id: linkId,
+      }),
+    );
+  }
+
+  /**
+   * Verify a batch of payment links, returning only the still-active ones.
+   * @param linkIds - Array of link IDs to verify
+   * @returns A promise resolving to an array of active link IDs
+   */
+  async verifyBatch(linkIds: string[]): Promise<string[]> {
+    return withMappedContractError(() =>
+      this.getContract().verify_batch({
+        link_ids: linkIds,
+      }),
+    );
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -25,6 +25,12 @@ import {
 import { NetworkProfileSwitcher, NetworkEnvironment, NetworkProfiles, NetworkProfile } from "./network-profiles.js";
 import { FxOracleClient } from "./contracts/fx-oracle.js";
 import { MerchantRegistryClient } from "./contracts/merchant-registry.js";
+import {
+  PaymentLinkManagerClient,
+  type PaymentLinkManagerConfig,
+  type PaymentLink,
+  type CreateLinkParams,
+} from "./contracts/payment-link-manager.js";
 
 export interface FluxapayConfig {
   network: NetworkEnvironment;
@@ -34,6 +40,8 @@ export interface FluxapayConfig {
   oracleContractId?: string;
   /** MerchantRegistry contract ID for merchant management operations. */
   merchantRegistryContractId?: string;
+  /** PaymentLinkManager contract ID for payment link operations. */
+  paymentLinkContractId?: string;
 }
 
 export interface CreatePaymentParams {
@@ -202,6 +210,7 @@ export class FluxapayClient {
   public networkSwitcher: NetworkProfileSwitcher;
   private fxOracleClient?: FxOracleClient;
   private merchantRegistryClient?: MerchantRegistryClient;
+  private paymentLinkManagerClient?: PaymentLinkManagerClient;
   private readonly config: FluxapayConfig;
 
   constructor(config: FluxapayConfig) {
@@ -274,6 +283,7 @@ export class FluxapayClient {
     });
     this.fxOracleClient = undefined;
     this.merchantRegistryClient = undefined;
+    this.paymentLinkManagerClient = undefined;
   }
 
   /**
@@ -525,6 +535,85 @@ export class FluxapayClient {
     );
   }
 
+  private getPaymentLinkManager(): PaymentLinkManagerClient {
+    if (!this.config.paymentLinkContractId) {
+      throw new Error(
+        "paymentLinkContractId is required in FluxapayConfig for payment link operations",
+      );
+    }
+
+    if (!this.paymentLinkManagerClient) {
+      const profile = this.networkSwitcher.getProfile();
+      this.paymentLinkManagerClient = new PaymentLinkManagerClient({
+        network: profile.environment,
+        rpcUrl: this.config.rpcUrl || profile.rpcUrl,
+        contractId: this.config.paymentLinkContractId,
+      });
+    }
+
+    return this.paymentLinkManagerClient;
+  }
+
+  /**
+   * Create a new payment link.
+   * Maps to `PaymentLinkManager.create_link` on-chain.
+   * @param params.merchant - The merchant's Stellar address
+   * @param params.amount - Optional fixed amount in stroops
+   * @param params.usdcToken - USDC token contract address
+   * @param params.metadata - Optional key/value metadata
+   * @returns A promise resolving to the new link ID
+   */
+  async createLink(params: CreateLinkParams): Promise<string> {
+    return this.getPaymentLinkManager().createLink(params);
+  }
+
+  /**
+   * Use a payment link to initiate a payment.
+   * Maps to `PaymentLinkManager.use_link` on-chain.
+   * @param payer - The payer's Stellar address
+   * @param linkId - The payment link ID
+   * @param amount - The amount to pay in stroops
+   * @param usdcToken - The USDC token contract address
+   */
+  async useLink(
+    payer: string,
+    linkId: string,
+    amount: bigint,
+    usdcToken: string,
+  ): Promise<void> {
+    return this.getPaymentLinkManager().useLink(payer, linkId, amount, usdcToken);
+  }
+
+  /**
+   * Deactivate a payment link (merchant only).
+   * Maps to `PaymentLinkManager.deactivate_link` on-chain.
+   * @param merchant - The merchant's Stellar address
+   * @param linkId - The payment link ID to deactivate
+   */
+  async deactivateLink(merchant: string, linkId: string): Promise<void> {
+    return this.getPaymentLinkManager().deactivateLink(merchant, linkId);
+  }
+
+  /**
+   * Retrieve details of a specific payment link.
+   * Maps to `PaymentLinkManager.get_link` on-chain.
+   * @param linkId - The payment link ID
+   * @returns A promise resolving to the PaymentLink details
+   */
+  async getLink(linkId: string): Promise<PaymentLink> {
+    return this.getPaymentLinkManager().getLink(linkId);
+  }
+
+  /**
+   * Verify a batch of payment links, returning only active ones.
+   * Maps to `PaymentLinkManager.verify_batch` on-chain.
+   * @param linkIds - Array of link IDs to verify
+   * @returns A promise resolving to an array of active link IDs
+   */
+  async verifyBatch(linkIds: string[]): Promise<string[]> {
+    return this.getPaymentLinkManager().verifyBatch(linkIds);
+  }
+
   /** Offline/hardware wallet payload builder utilities. */
   offlineSigner(): FluxapayOfflineSigner {
     return new FluxapayOfflineSigner(
@@ -571,3 +660,9 @@ export {
   type RateData,
   FX_ORACLE_ERROR_MAP,
 } from "./contracts/fx-oracle.js";
+export {
+  PaymentLinkManagerClient,
+  type PaymentLinkManagerConfig,
+  type PaymentLink,
+  type CreateLinkParams,
+} from "./contracts/payment-link-manager.js";


### PR DESCRIPTION
## Summary

This PR addresses two open issues in a single branch:

- **fix #380** — Remove committed `actionlint` binary from repo root
- **feat #387** — Add payment link methods to the TypeScript SDK

---

## Changes

### fix: remove committed actionlint binary from repo root (#380)

The repository had a 5.5 MB platform-specific `actionlint` binary committed directly to the root, causing repo bloat, cross-platform CI failures, and supply-chain risk.

**What changed:**
- Removed the binary via `git rm actionlint`
- Added `/actionlint` to `.gitignore` to prevent re-committing
- Added a new `actionlint` CI job in `.github/workflows/ci.yml` that installs via the pinned, verifiable `rhysd/actionlint@v1` action
- Wired the `actionlint` job into the `ci-success` gate
- Documented local `actionlint` installation and usage in `CONTRIBUTING.md`

**Files changed:**
- `actionlint` — deleted
- `.gitignore` — added `/actionlint` entry
- `.github/workflows/ci.yml` — added `actionlint` job; updated `ci-success` needs array
- `CONTRIBUTING.md` — added _Linting GitHub Actions Workflows (actionlint)_ section

---

### feat(sdk): add payment link methods to TypeScript SDK (#387)

The TypeScript SDK had no support for `PaymentLinkManager` contract interactions. Merchants could not create, use, or deactivate payment links through the typed SDK.

**What changed:**
- Created `sdk/src/contracts/payment-link-manager.ts` — standalone `PaymentLinkManagerClient` with all five methods
- Added `PaymentLink` interface and `CreateLinkParams` interface with `metadata` typed as `Record<string, string> | undefined`
- Extended `FluxapayClient` with all five payment link methods delegating to `PaymentLinkManagerClient`:
  - `createLink(params)` → `PaymentLinkManager.create_link`
  - `useLink(payer, linkId, amount, usdcToken)` → `use_link`
  - `deactivateLink(merchant, linkId)` → `deactivate_link`
  - `getLink(linkId)` → `get_link`
  - `verifyBatch(linkIds)` → `verify_batch`
- Added `paymentLinkContractId` field to `FluxapayConfig`
- Exported `PaymentLink`, `CreateLinkParams`, `PaymentLinkManagerClient`, and `PaymentLinkManagerConfig` from the SDK index
- Updated `sdk/README.md` with a full _Payment Links_ section covering all five methods and standalone client usage

**Files changed:**
- `sdk/src/contracts/payment-link-manager.ts` — new file
- `sdk/src/index.ts` — new imports, config field, client field, helper, 5 methods, exports
- `sdk/README.md` — added Payment Links documentation section

---

## Testing

- `npm run build` passes with exit code `0` (TypeScript compilation clean, no errors)
- All five methods follow the same `withMappedContractError` error-mapping pattern used throughout the existing SDK
- No existing tests broken; new code is additive only

---

## Acceptance Criteria Checklist

### #380
- [x] `actionlint` binary removed from repository root
- [x] `/actionlint` added to `.gitignore`
- [x] CI installs actionlint via `rhysd/actionlint@v1` (pinned, verifiable)
- [x] `CONTRIBUTING.md` documents local usage
- [x] Removal uses `git rm`

### #387
- [x] `createLink`, `useLink`, `deactivateLink`, `getLink`, `verifyBatch` implemented in `FluxapayClient`
- [x] `createLink` includes `metadata` as `Record<string, string> | undefined`
- [x] `PaymentLink` type exported from the SDK
- [x] SDK README updated with payment link usage examples
- [x] `npm run build` passes

---

## Related Issues

Closes #380
Closes #387
