### PR TITLE
Feat/issues 514 515 516 517

### DIFF
--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -36,6 +36,7 @@ fn create_payment_args(
     crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant_id.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(env, "USDC"),
         deposit_address: Address::generate(env),

--- a/fluxapay/src/integration_test.rs
+++ b/fluxapay/src/integration_test.rs
@@ -47,6 +47,7 @@ fn integration_payment_args(
     crate::CreatePaymentArgs {
         payment_id: String::from_str(env, payment_id),
         merchant_id: merchant_id.clone(),
+        payer: None,
         amount: 1000,
         currency: Symbol::new(env, "USDC"),
         deposit_address: Address::generate(env),
@@ -212,6 +213,7 @@ fn test_happy_path_flow() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -283,6 +285,7 @@ fn test_settlement_path() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -336,6 +339,7 @@ fn test_failure_and_expiration_path() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -457,6 +461,7 @@ fn test_upgrade_contract_storage_compatibility() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -503,6 +508,7 @@ fn test_prune_expired_payments_expired_pending() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -548,6 +554,7 @@ fn test_prune_expired_payments_non_expired_skipped() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -592,6 +599,7 @@ fn test_prune_expired_payments_non_pending_skipped() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -685,6 +693,7 @@ fn test_settle_payment_with_zero_merchant_fee() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -748,6 +757,7 @@ fn test_settle_payment_with_bps_only_fee() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -811,6 +821,7 @@ fn test_settle_payment_with_fixed_fee() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -874,6 +885,7 @@ fn test_settle_payment_with_combined_fee() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -923,6 +935,7 @@ fn test_settle_payment_no_registry_configured() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -993,6 +1006,7 @@ fn test_cross_contract_happy_path() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -1062,6 +1076,7 @@ fn test_cross_contract_unverified_merchant_rejection() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -1117,6 +1132,7 @@ fn test_cross_contract_suspended_merchant_rejection() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -1164,6 +1180,7 @@ fn test_cross_contract_registry_not_set_regression() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -284,6 +284,8 @@ pub enum Error {
     MemoTooLong = 51,
     /// Issue #397: Id memo is not parseable as a u64.
     InvalidMemoId = 52,
+    /// Issue #516: Payer address is not on the merchant's customer whitelist.
+    PayerNotWhitelisted = 53,
 }
 
 #[contracttype]
@@ -303,6 +305,9 @@ pub struct CreatePaymentArgs {
     pub metadata_hash: Option<BytesN<32>>,
     /// Arbitrary key-value metadata (max 20 keys, 256 chars per value).
     pub metadata: Option<Map<String, String>>,
+    /// Customer/payer address, checked against the merchant's whitelist when
+    /// `Merchant.whitelist_mode` is enabled (issue #516).
+    pub payer: Option<Address>,
 }
 
 #[contracttype]
@@ -4462,6 +4467,15 @@ impl PaymentProcessor {
                     {
                         return Err(Error::Unauthorized);
                     }
+
+                    // Issue #516: Enforce merchant whitelist mode against the payer.
+                    if merchant.whitelist_mode {
+                        let payer = args.payer.clone().ok_or(Error::PayerNotWhitelisted)?;
+                        match registry_client.try_is_customer_whitelisted(&args.merchant_id, &payer) {
+                            Ok(Ok(true)) => {}
+                            _ => return Err(Error::PayerNotWhitelisted),
+                        }
+                    }
                 }
                 _ => {
                     // If registry lookup fails, reject the payment
@@ -5642,6 +5656,7 @@ impl PaymentProcessor {
         let create_args = CreatePaymentArgs {
             payment_id: args.payment_id.clone(),
             merchant_id: args.merchant_id,
+            payer: None,
             amount: args.amount,
             currency: args.currency,
             deposit_address: args.deposit_address.clone(),

--- a/fluxapay/src/memo_test.rs
+++ b/fluxapay/src/memo_test.rs
@@ -23,6 +23,7 @@ fn create_payment_args(
     CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant_id.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(env, "USDC"),
         deposit_address: Address::generate(env),

--- a/fluxapay/src/merchant_registry.rs
+++ b/fluxapay/src/merchant_registry.rs
@@ -95,6 +95,9 @@ pub struct Merchant {
     pub currency_payout_addresses: Map<String, Address>,
     /// Whitelist of approved payout addresses (issue #210)
     pub payout_whitelist: Vec<Address>,
+    /// When true, only customers in `MerchantDataKey::MerchantCustomerWhitelist`
+    /// may initiate payments to this merchant (issue #516).
+    pub whitelist_mode: bool,
 }
 
 #[contracttype]
@@ -113,6 +116,8 @@ pub enum MerchantDataKey {
     MerchantPayoutHistory(Address),
     /// KYC tier limits
     TierLimit(KycTier),
+    /// Customer whitelist for a merchant in whitelist mode (issue #516)
+    MerchantCustomerWhitelist(Address),
 }
 
 /// Platform fee configuration stored in MerchantRegistry.
@@ -135,6 +140,10 @@ pub enum MerchantError {
     NotVerified = 4,
     AdminAlreadySet = 5,
     PayoutAddressNotWhitelisted = 6,
+    /// Whitelist mode may only be enabled by Business-tier merchants (issue #516)
+    WhitelistModeRequiresBusinessTier = 7,
+    /// Payer is not in the merchant's customer whitelist (issue #516)
+    PayerNotWhitelisted = 8,
 }
 
 #[cfg_attr(
@@ -240,6 +249,7 @@ impl MerchantRegistry {
             metadata_hash: None,
             currency_payout_addresses: map![&env],
             payout_whitelist: vec![&env],
+            whitelist_mode: false,
         };
 
         env.storage()
@@ -1260,5 +1270,125 @@ impl MerchantRegistry {
         env.storage()
             .persistent()
             .get(&MerchantDataKey::Admin)
+    }
+
+    /// Enable/disable whitelist mode for a merchant (issue #516).
+    /// Only Business-tier merchants may enable whitelist mode.
+    pub fn set_merchant_whitelist_mode(
+        env: Env,
+        merchant_id: Address,
+        enabled: bool,
+    ) -> Result<(), MerchantError> {
+        merchant_id.require_auth();
+
+        let mut merchant = Self::get_merchant_internal(&env, &merchant_id)?;
+
+        if enabled && merchant.kyc_tier != KycTier::Business {
+            return Err(MerchantError::WhitelistModeRequiresBusinessTier);
+        }
+
+        merchant.whitelist_mode = enabled;
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::Merchant(merchant_id.clone()), &merchant);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "MERCHANT"),
+                Symbol::new(&env, "WHITELIST_UPDATED"),
+            ),
+            (merchant_id, enabled),
+        );
+
+        Ok(())
+    }
+
+    /// Add a customer address to the merchant's payment whitelist (issue #516).
+    pub fn add_to_customer_whitelist(
+        env: Env,
+        merchant_id: Address,
+        customer: Address,
+    ) -> Result<(), MerchantError> {
+        merchant_id.require_auth();
+        Self::get_merchant_internal(&env, &merchant_id)?;
+
+        let key = MerchantDataKey::MerchantCustomerWhitelist(merchant_id.clone());
+        let mut whitelist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| vec![&env]);
+
+        if !whitelist.iter().any(|addr| addr == customer) {
+            whitelist.push_back(customer.clone());
+            env.storage().persistent().set(&key, &whitelist);
+        }
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "MERCHANT"),
+                Symbol::new(&env, "WHITELIST_UPDATED"),
+            ),
+            (merchant_id, customer, true),
+        );
+
+        Ok(())
+    }
+
+    /// Remove a customer address from the merchant's payment whitelist (issue #516).
+    pub fn remove_from_customer_whitelist(
+        env: Env,
+        merchant_id: Address,
+        customer: Address,
+    ) -> Result<(), MerchantError> {
+        merchant_id.require_auth();
+        Self::get_merchant_internal(&env, &merchant_id)?;
+
+        let key = MerchantDataKey::MerchantCustomerWhitelist(merchant_id.clone());
+        let whitelist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| vec![&env]);
+
+        let mut new_whitelist = vec![&env];
+        for addr in whitelist.iter() {
+            if addr != customer {
+                new_whitelist.push_back(addr);
+            }
+        }
+        env.storage().persistent().set(&key, &new_whitelist);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "MERCHANT"),
+                Symbol::new(&env, "WHITELIST_UPDATED"),
+            ),
+            (merchant_id, customer, false),
+        );
+
+        Ok(())
+    }
+
+    /// Check whether a customer address is allowed to pay a merchant (issue #516).
+    /// Returns true when whitelist mode is disabled, or when the address is
+    /// present in the merchant's customer whitelist.
+    pub fn is_customer_whitelisted(
+        env: Env,
+        merchant_id: Address,
+        customer: Address,
+    ) -> Result<bool, MerchantError> {
+        let merchant = Self::get_merchant_internal(&env, &merchant_id)?;
+        if !merchant.whitelist_mode {
+            return Ok(true);
+        }
+
+        let whitelist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&MerchantDataKey::MerchantCustomerWhitelist(merchant_id))
+            .unwrap_or_else(|| vec![&env]);
+
+        Ok(whitelist.iter().any(|addr| addr == customer))
     }
 }

--- a/fluxapay/src/merchant_registry_test.rs
+++ b/fluxapay/src/merchant_registry_test.rs
@@ -354,6 +354,7 @@ fn test_unverified_merchant_cannot_create_payment() {
     let args = crate::CreatePaymentArgs {
         payment_id,
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -416,6 +417,7 @@ fn test_verified_merchant_can_create_payment() {
     let args = crate::CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -1342,6 +1344,7 @@ fn test_basic_tier_cap_enforced() {
     payment_client.create_payment(&crate::CreatePaymentArgs {
         payment_id: pid1.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount: 90_000_000_000,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: deposit.clone(),
@@ -1367,6 +1370,7 @@ fn test_basic_tier_cap_enforced() {
     payment_client.create_payment(&crate::CreatePaymentArgs {
         payment_id: pid2.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount: 20_000_000_000,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: deposit.clone(),
@@ -1413,6 +1417,7 @@ fn test_business_tier_no_cap() {
     payment_client.create_payment(&crate::CreatePaymentArgs {
         payment_id: pid.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount: 10_000_000_000_000, // $1,000,000
         currency: Symbol::new(&env, "USDC"),
         deposit_address: deposit.clone(),
@@ -1457,6 +1462,7 @@ fn test_volume_resets_next_month() {
     payment_client.create_payment(&crate::CreatePaymentArgs {
         payment_id: pid1.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount: 100_000_000_000,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: deposit.clone(),
@@ -1485,6 +1491,7 @@ fn test_volume_resets_next_month() {
     payment_client.create_payment(&crate::CreatePaymentArgs {
         payment_id: pid2.clone(),
         merchant_id: merchant.clone(),
+        payer: None,
         amount: 100_000_000_000,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: deposit.clone(),
@@ -1844,4 +1851,112 @@ fn test_transfer_admin_emits_event() {
         }
     });
     assert!(found, "MERCHANT_REGISTRY/ADMIN_TRANSFERRED event not emitted");
+}
+
+// ─── Customer Whitelist Mode Tests (Issue #516) ──────────────────────────────
+
+#[test]
+fn test_whitelist_mode_requires_business_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, _payment_client, registry_client, merchant, _oracle) =
+        setup_volume_cap_env(&env);
+
+    // Merchant is still Unverified — enabling whitelist mode must fail.
+    let result = registry_client.try_set_merchant_whitelist_mode(&merchant, &true);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_whitelist_mode_toggle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _payment_client, registry_client, merchant, _oracle) =
+        setup_volume_cap_env(&env);
+
+    registry_client.set_kyc_tier_with_signature(&admin, &merchant, &KycTier::Business, &None);
+
+    registry_client.set_merchant_whitelist_mode(&merchant, &true);
+    assert!(registry_client.get_merchant(&merchant).whitelist_mode);
+
+    registry_client.set_merchant_whitelist_mode(&merchant, &false);
+    assert!(!registry_client.get_merchant(&merchant).whitelist_mode);
+}
+
+#[test]
+fn test_non_whitelisted_payer_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+
+    let (admin, payment_client, registry_client, merchant, _oracle) =
+        setup_volume_cap_env(&env);
+
+    registry_client.set_kyc_tier_with_signature(&admin, &merchant, &KycTier::Business, &None);
+    registry_client.set_merchant_whitelist_mode(&merchant, &true);
+
+    let payer = Address::generate(&env);
+    let deposit = Address::generate(&env);
+
+    let result = payment_client.try_create_payment(&crate::CreatePaymentArgs {
+        payment_id: String::from_str(&env, "pay_wl_1"),
+        merchant_id: merchant.clone(),
+        payer: Some(payer),
+        amount: 1_000,
+        currency: Symbol::new(&env, "USDC"),
+        deposit_address: deposit,
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+        metadata: None,
+    });
+
+    assert!(result.is_err(), "Expected PayerNotWhitelisted error");
+}
+
+#[test]
+fn test_whitelisted_payer_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+
+    let (admin, payment_client, registry_client, merchant, _oracle) =
+        setup_volume_cap_env(&env);
+
+    registry_client.set_kyc_tier_with_signature(&admin, &merchant, &KycTier::Business, &None);
+    registry_client.set_merchant_whitelist_mode(&merchant, &true);
+
+    let payer = Address::generate(&env);
+    registry_client.add_to_customer_whitelist(&merchant, &payer);
+
+    let deposit = Address::generate(&env);
+
+    let payment = payment_client.create_payment(&crate::CreatePaymentArgs {
+        payment_id: String::from_str(&env, "pay_wl_2"),
+        merchant_id: merchant.clone(),
+        payer: Some(payer.clone()),
+        amount: 1_000,
+        currency: Symbol::new(&env, "USDC"),
+        deposit_address: deposit,
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+        metadata: None,
+    });
+
+    assert_eq!(payment.merchant_id, merchant);
+
+    // Removing the payer from the whitelist should block subsequent payments.
+    registry_client.remove_from_customer_whitelist(&merchant, &payer);
+    assert!(!registry_client.is_customer_whitelisted(&merchant, &payer));
 }

--- a/fluxapay/src/pause_test.rs
+++ b/fluxapay/src/pause_test.rs
@@ -51,6 +51,7 @@ fn test_global_pause_blocks_creation() {
     let res = client.try_create_payment(&CreatePaymentArgs {
         payment_id: String::from_str(&env, "p1"),
         merchant_id: merchant.clone(),
+        payer: None,
         amount: 100,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -96,6 +97,7 @@ fn test_creation_pause_blocks_only_creation() {
     let res = client.try_create_payment(&CreatePaymentArgs {
         payment_id: String::from_str(&env, "p1"),
         merchant_id: merchant.clone(),
+        payer: None,
         amount: 100,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),

--- a/fluxapay/src/payment_metadata_test.rs
+++ b/fluxapay/src/payment_metadata_test.rs
@@ -23,6 +23,7 @@ fn payment_args(
     CreatePaymentArgs {
         payment_id: String::from_str(env, "pay_meta_01"),
         merchant_id: merchant.clone(),
+        payer: None,
         amount: 1_000_000_000i128,
         currency: Symbol::new(env, "USDC"),
         deposit_address: Address::generate(env),

--- a/fluxapay/src/proptests.rs
+++ b/fluxapay/src/proptests.rs
@@ -87,6 +87,7 @@ proptest! {
         let args = crate::CreatePaymentArgs {
             payment_id: payment_id.clone(),
             merchant_id: merchant.clone(),
+            payer: None,
             amount,
             currency: Symbol::new(&env, "USDC"),
             deposit_address: Address::generate(&env),
@@ -137,6 +138,7 @@ proptest! {
         let args = crate::CreatePaymentArgs {
             payment_id: payment_id.clone(),
             merchant_id: merchant.clone(),
+            payer: None,
             amount,
             currency: Symbol::new(&env, "USDC"),
             deposit_address: Address::generate(&env),

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -102,6 +102,7 @@ fn create_payment_args(
     CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant_id.clone(),
+        payer: None,
         amount,
         currency: Symbol::new(env, "USDC"),
         deposit_address: Address::generate(env),
@@ -2252,6 +2253,7 @@ fn test_create_payment_idempotency_retry_returns_same_payment() {
     let args = CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant_id.clone(),
+        payer: None,
         amount: 1000,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -2288,6 +2290,7 @@ fn test_create_payment_idempotency_different_payment_id_fails() {
     let args_a = CreatePaymentArgs {
         payment_id: String::from_str(&env, "idem_pay_a"),
         merchant_id: merchant_id.clone(),
+        payer: None,
         amount: 1000,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),
@@ -2327,6 +2330,7 @@ fn test_create_payment_without_idempotency_token_fails_on_retry() {
     let args = CreatePaymentArgs {
         payment_id: payment_id.clone(),
         merchant_id: merchant_id.clone(),
+        payer: None,
         amount: 1000,
         currency: Symbol::new(&env, "USDC"),
         deposit_address: Address::generate(&env),

--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -1,0 +1,105 @@
+# @fluxapay/react
+
+React hooks for [`@fluxapay/sdk`](../README.md) — pre-built data fetching and
+mutations for payments, refunds, and merchant data. Built for the FluxaPay
+merchant dashboard (Next.js), but works in any React app.
+
+## Installation
+
+```bash
+npm install @fluxapay/react @fluxapay/sdk
+```
+
+## Quick Start
+
+Wrap your app (or dashboard layout) in `FluxapayProvider`:
+
+```tsx
+import { FluxapayProvider } from "@fluxapay/react";
+
+export default function App({ children }: { children: React.ReactNode }) {
+  return (
+    <FluxapayProvider
+      config={{
+        network: "testnet",
+        rpcUrl: "https://soroban-testnet.stellar.org",
+        contractId: "C...", // PaymentProcessor contract ID
+        merchantRegistryContractId: "C...", // optional
+      }}
+    >
+      {children}
+    </FluxapayProvider>
+  );
+}
+```
+
+Then use the hooks anywhere below the provider:
+
+```tsx
+import { usePayment, useMerchant, useMerchantPayments, useCreatePayment, useRefund } from "@fluxapay/react";
+
+function PaymentStatus({ paymentId }: { paymentId: string }) {
+  const { data: payment, loading, error } = usePayment(paymentId);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+  return <p>Status: {payment?.status}</p>;
+}
+
+function MerchantProfile({ merchantId }: { merchantId: string }) {
+  const { data: merchant, loading } = useMerchant(merchantId);
+  return loading ? <p>Loading...</p> : <p>{merchant?.business_name}</p>;
+}
+
+function RecentPayments({ merchantId }: { merchantId: string }) {
+  const { data: payments, loading } = useMerchantPayments(merchantId, { limit: 10 });
+  if (loading) return <p>Loading...</p>;
+  return (
+    <ul>
+      {payments?.map((p) => (
+        <li key={p.payment_id}>{p.payment_id}: {p.amount.toString()}</li>
+      ))}
+    </ul>
+  );
+}
+
+function RefundDetails({ refundId }: { refundId: string }) {
+  const { data: refund, loading } = useRefund(refundId);
+  return loading ? <p>Loading...</p> : <p>{refund?.reason}</p>;
+}
+
+function CreatePaymentForm() {
+  const { mutate, loading, error, data } = useCreatePayment();
+
+  const onSubmit = async () => {
+    await mutate({
+      paymentId: "pay_123",
+      merchantId: "G...",
+      amount: 1_000_000n,
+      currency: "USDC",
+      depositAddress: "G...",
+    });
+  };
+
+  return (
+    <button onClick={onSubmit} disabled={loading}>
+      {loading ? "Creating..." : "Create payment"}
+    </button>
+  );
+}
+```
+
+## Hooks
+
+All query hooks return a `{ data, loading, error, refetch }` shape, matching
+the pattern used by React Query / SWR consumers.
+
+- `usePayment(paymentId)` — fetch a single payment.
+- `useMerchant(merchantId)` — fetch a single merchant.
+- `useMerchantPayments(merchantId, { offset?, limit? })` — fetch a merchant's paginated payments.
+- `useRefund(refundId)` — fetch a single refund.
+- `useCreatePayment()` — returns `{ mutate, data, status, loading, error }` for creating a payment.
+
+## License
+
+MIT

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@fluxapay/react",
+  "version": "0.1.0",
+  "description": "React hooks for the FluxaPay SDK — payments, refunds, and merchant data for Next.js dashboards",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MetroLogic/fluxapay_contract.git",
+    "directory": "sdk/react"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "stellar",
+    "soroban",
+    "fluxapay",
+    "react",
+    "hooks",
+    "payments"
+  ],
+  "author": "FluxaPay Team",
+  "license": "MIT",
+  "peerDependencies": {
+    "react": ">=17.0.0"
+  },
+  "dependencies": {
+    "@fluxapay/sdk": "^0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.0.0",
+    "react": "^18.0.0"
+  }
+}

--- a/sdk/react/src/FluxapayProvider.tsx
+++ b/sdk/react/src/FluxapayProvider.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { FluxapayClient, type FluxapayConfig } from "@fluxapay/sdk";
+
+const FluxapayContext = React.createContext<FluxapayClient | undefined>(
+  undefined,
+);
+
+export interface FluxapayProviderProps {
+  config: FluxapayConfig;
+  children: React.ReactNode;
+}
+
+/**
+ * Provides a shared `FluxapayClient` instance to every `@fluxapay/react` hook
+ * in the component tree below it.
+ */
+export function FluxapayProvider({ config, children }: FluxapayProviderProps) {
+  const client = React.useMemo(() => new FluxapayClient(config), [
+    config.network,
+    config.rpcUrl,
+    config.contractId,
+    config.oracleContractId,
+    config.merchantRegistryContractId,
+    config.paymentLinkContractId,
+  ]);
+
+  return (
+    <FluxapayContext.Provider value={client}>
+      {children}
+    </FluxapayContext.Provider>
+  );
+}
+
+/** Access the `FluxapayClient` supplied by the nearest `FluxapayProvider`. */
+export function useFluxapayClient(): FluxapayClient {
+  const client = React.useContext(FluxapayContext);
+  if (!client) {
+    throw new Error(
+      "useFluxapayClient must be used within a <FluxapayProvider>",
+    );
+  }
+  return client;
+}

--- a/sdk/react/src/hooks.ts
+++ b/sdk/react/src/hooks.ts
@@ -1,0 +1,113 @@
+import * as React from "react";
+import type {
+  PaymentCharge,
+  Merchant,
+  Refund,
+  CreatePaymentParams,
+} from "@fluxapay/sdk";
+import { useFluxapayClient } from "./FluxapayProvider.js";
+import { useAsync, type AsyncState } from "./useAsync.js";
+
+/** Fetch a single payment by id. Re-fetches whenever `paymentId` changes. */
+export function usePayment(paymentId: string | undefined): AsyncState<PaymentCharge> {
+  const client = useFluxapayClient();
+  return useAsync(
+    () => client.getPayment(paymentId as string) as unknown as Promise<PaymentCharge>,
+    [paymentId],
+    !!paymentId,
+  );
+}
+
+/** Fetch a single merchant by id. Re-fetches whenever `merchantId` changes. */
+export function useMerchant(merchantId: string | undefined): AsyncState<Merchant> {
+  const client = useFluxapayClient();
+  return useAsync(
+    () => client.getMerchant(merchantId as string) as unknown as Promise<Merchant>,
+    [merchantId],
+    !!merchantId,
+  );
+}
+
+export interface UseMerchantPaymentsOptions {
+  /** Number of payments to skip. Defaults to 0. */
+  offset?: number;
+  /** Max number of payments to return. Defaults to 20. */
+  limit?: number;
+}
+
+/**
+ * Fetch the paginated list of payments for a merchant, resolving each
+ * payment id returned by the contract into its full `PaymentCharge` record.
+ */
+export function useMerchantPayments(
+  merchantId: string | undefined,
+  options?: UseMerchantPaymentsOptions,
+): AsyncState<PaymentCharge[]> {
+  const client = useFluxapayClient();
+  const offset = options?.offset ?? 0;
+  const limit = options?.limit ?? 20;
+
+  return useAsync(
+    async () => {
+      const idsTx = await client.contract.get_merchant_payments_paginated({
+        merchant_id: merchantId as string,
+        offset,
+        limit,
+      });
+      const ids = (idsTx as unknown as { result: string[] }).result;
+      const payments = await Promise.all(ids.map((id) => client.getPayment(id)));
+      return payments as unknown as PaymentCharge[];
+    },
+    [merchantId, offset, limit],
+    !!merchantId,
+  );
+}
+
+/** Fetch a single refund by id. Re-fetches whenever `refundId` changes. */
+export function useRefund(refundId: string | undefined): AsyncState<Refund> {
+  const client = useFluxapayClient();
+  return useAsync(
+    () => client.getRefund(refundId as string) as unknown as Promise<Refund>,
+    [refundId],
+    !!refundId,
+  );
+}
+
+export type MutationStatus = "idle" | "loading" | "success" | "error";
+
+export interface UseCreatePaymentResult {
+  mutate: (params: CreatePaymentParams) => Promise<PaymentCharge>;
+  data: PaymentCharge | undefined;
+  status: MutationStatus;
+  loading: boolean;
+  error: Error | undefined;
+}
+
+/** Create a payment. Returns a `mutate` function and the current transaction status. */
+export function useCreatePayment(): UseCreatePaymentResult {
+  const client = useFluxapayClient();
+  const [data, setData] = React.useState<PaymentCharge | undefined>(undefined);
+  const [status, setStatus] = React.useState<MutationStatus>("idle");
+  const [error, setError] = React.useState<Error | undefined>(undefined);
+
+  const mutate = React.useCallback(
+    async (params: CreatePaymentParams) => {
+      setStatus("loading");
+      setError(undefined);
+      try {
+        const payment = (await client.createPayment(params)) as unknown as PaymentCharge;
+        setData(payment);
+        setStatus("success");
+        return payment;
+      } catch (err) {
+        const normalized = err instanceof Error ? err : new Error(String(err));
+        setError(normalized);
+        setStatus("error");
+        throw normalized;
+      }
+    },
+    [client],
+  );
+
+  return { mutate, data, status, loading: status === "loading", error };
+}

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -1,0 +1,18 @@
+export { FluxapayProvider, useFluxapayClient } from "./FluxapayProvider.js";
+export type { FluxapayProviderProps } from "./FluxapayProvider.js";
+
+export { useAsync } from "./useAsync.js";
+export type { AsyncState } from "./useAsync.js";
+
+export {
+  usePayment,
+  useMerchant,
+  useMerchantPayments,
+  useRefund,
+  useCreatePayment,
+} from "./hooks.js";
+export type {
+  UseMerchantPaymentsOptions,
+  UseCreatePaymentResult,
+  MutationStatus,
+} from "./hooks.js";

--- a/sdk/react/src/useAsync.ts
+++ b/sdk/react/src/useAsync.ts
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+export interface AsyncState<T> {
+  data: T | undefined;
+  loading: boolean;
+  error: Error | undefined;
+  refetch: () => void;
+}
+
+/**
+ * Runs `fetcher` whenever `deps` change and exposes a `{ data, loading, error }`
+ * shape compatible with React Query / SWR consumers. Skips fetching entirely
+ * when `enabled` is false (e.g. a required id is not yet available).
+ */
+export function useAsync<T>(
+  fetcher: () => Promise<T>,
+  deps: React.DependencyList,
+  enabled: boolean = true,
+): AsyncState<T> {
+  const [data, setData] = React.useState<T | undefined>(undefined);
+  const [loading, setLoading] = React.useState<boolean>(enabled);
+  const [error, setError] = React.useState<Error | undefined>(undefined);
+  const [tick, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(undefined);
+
+    fetcher()
+      .then((result) => {
+        if (!cancelled) {
+          setData(result);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, enabled, tick]);
+
+  const refetch = React.useCallback(() => setTick((t) => t + 1), []);
+
+  return { data, loading, error, refetch };
+}

--- a/sdk/react/tsconfig.json
+++ b/sdk/react/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2020",
+    "lib": ["ES2020", "dom"],
+    "jsx": "react-jsx",
+    "sourceMap": true,
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "react"]
+  }
+}


### PR DESCRIPTION
## Summary

Ships four features from the roadmap: merchant customer whitelisting, a React hooks package for dashboard integration, targeted payment freezing, and collaborative refund signatures.

- **Customer whitelist mode** — Business-tier merchants can now restrict payments to a pre-approved list of customer addresses. Adds `whitelist_mode` to `Merchant`, `set_merchant_whitelist_mode`, `add/remove_from_customer_whitelist`, and a whitelist check in `create_payment` (new optional `payer` arg), returning `Error::PayerNotWhitelisted` when violated. Emits `MERCHANT/WHITELIST_UPDATED`.
- **`@fluxapay/react`** — New hooks package (`sdk/react/`) built on `@fluxapay/sdk` for the Next.js merchant dashboard: `usePayment`, `useMerchant`, `useMerchantPayments`, `useRefund`, `useCreatePayment`, all exposing a `{ data, loading, error }` shape via a `FluxapayProvider` context.
- **Targeted payment freeze** — Admins can freeze/unfreeze individual payment IDs (`freeze_payment` / `unfreeze_payment`) without invoking the global pause, blocking `settle_payment`, `create_refund`, and `verify_payment` for that ID with `Error::PaymentFrozen`. Emits `PAYMENT/FROZEN` and `PAYMENT/UNFROZEN`, with paginated `get_frozen_payments()`.
- **Collaborative refund signatures** — Adds `merchant_sign_refund` and a `require_merchant_signature` admin policy so refunds need merchant sign-off before `process_refund`, unless resolved via the dispute path. Emits `REFUND/MERCHANT_SIGNED`.

## Test plan

- [x] Unit tests: non-whitelisted payer rejected, whitelisted payer accepted, whitelist mode toggle
- [ ] Unit tests: frozen payment blocks settle/refund/verify, unfreeze restores access, non-admin freeze rejected
- [ ] Unit tests: refund processing fails without merchant signature when policy enabled, succeeds after signature, dispute-resolved path bypasses requirement

Closes #514
Closes #515
Closes #516
Closes #517