### PR TITLE
Feat/daemon health dlq contributing events sdk ci check deploy funding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,7 @@ jobs:
               }
             }
 
-  # Job 6: Check SDK build
+  # Job 6: Check SDK build and types
   sdk-check:
     name: SDK Build Check
     runs-on: ubuntu-latest
@@ -397,17 +397,21 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "lts/*"
           cache: "npm"
-          cache-working-directory: sdk
+          cache-dependency-path: sdk/package-lock.json
 
       - name: Install dependencies
         working-directory: sdk
-        run: npm install
+        run: npm ci
 
       - name: Build SDK
         working-directory: sdk
         run: npm run build
+
+      - name: Type check
+        working-directory: sdk
+        run: npx tsc --noEmit
 
       - name: Test SDK
         working-directory: sdk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ For security vulnerabilities, see [SECURITY.md](SECURITY.md) instead of opening 
 5. [Branch Naming Conventions](#5-branch-naming-conventions)
 6. [Commit Message Format](#6-commit-message-format)
 7. [Pull Request Requirements](#7-pull-request-requirements)
+   - [Adding Contract Events](#72-adding-contract-events)
 8. [Issue Workflow](#8-issue-workflow)
 
 ---
@@ -222,6 +223,46 @@ This repository uses [Dependabot](https://docs.github.com/en/code-security/depen
 5. **For major version bumps**: Additional manual testing may be required before merging
 
 > **Note**: Dependabot runs weekly. If you need an urgent security update, you can manually trigger it via the [Dependabot dashboard](https://github.com/Yunusabdul38/fluxapay_contract/security/dependabot).
+
+---
+
+## 7.2. Adding Contract Events
+
+FluxaPay contract events are defined with `#[contractevent]`. Follow these steps when adding a new one:
+
+1. **Define the event struct** in [`fluxapay/src/events.rs`](fluxapay/src/events.rs):
+
+   ```rust
+   #[contractevent]
+   #[derive(Clone, Debug)]
+   pub struct MerchantSuspended {
+       pub merchant_id: Address,
+       pub reason: Symbol,
+   }
+   ```
+
+2. **Emit it in the correct entry point** — call `.publish()` on the event from the contract function that triggers it:
+
+   ```rust
+   MerchantSuspended {
+       merchant_id: merchant_id.clone(),
+       reason: Symbol::new(&env, "compliance_hold"),
+   }
+   .publish(&env);
+   ```
+
+3. **Update the event catalog** in [`docs/events.md`](docs/events.md) — add a section documenting the event's fields, emitting function(s), and an example payload.
+
+4. **Add an indexer subscription** in [`indexer/sync.yml`](indexer/sync.yml) under the relevant contract's `events` list so the indexer picks up the new event.
+
+5. **Add the SDK event type** in `sdk/src` so consumers of the TypeScript SDK get typed access to the new event.
+
+**Worked example — adding `MerchantSuspended`:**
+- Struct added to `fluxapay/src/events.rs` under a `// Merchant Registry Events` section
+- Emitted from `merchant_registry::suspend_merchant`
+- Documented in `docs/events.md` under `## MERCHANT / SUSPENDED`
+- Subscribed to in `indexer/sync.yml` under the `merchant_registry` contract mapping
+- Typed in the SDK alongside the other merchant registry events
 
 ---
 


### PR DESCRIPTION
## Summary

- **docs**: add "Adding Contract Events" section to `CONTRIBUTING.md` — step-by-step guide from defining a `#[contractevent]` struct through indexer/SDK registration, with a worked `MerchantSuspended` example
- **ci**: add SDK TypeScript build and type-check to the CI pipeline — `npm ci`, `npm run build`, `npx tsc --noEmit` on Node.js LTS, running in parallel with the Rust build job and gated by `ci-success`
- **feat**: add `/health` endpoint and dead-letter queue to `scripts/subscription-daemon.js` for failed subscription events, with a `/reprocess` endpoint and `--dry-run` flag
- **feat**: add Stellar testnet Friendbot auto-funding to `scripts/deploy_testnet.sh`, with a balance check, retry, and mainnet skip/warning

## Test plan

- [ ] CI passes (`sdk-check`, `format`, `lint`, `security-audit`, `build`, `test`)
- [ ] `CONTRIBUTING.md` renders correctly and links resolve
- [ ] `subscription-daemon.js --dry-run` processes events without DB writes; `/health` and `/reprocess` return expected responses
- [ ] `deploy_testnet.sh` funds an underfunded testnet account via Friendbot and skips auto-funding on mainnet

Closes #511
Closes #506
Closes #510
Closes #513