### PR TITLE
feat: webhooks docs, treasury unification, batch disputes, link max_uses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ fluxapay/test_snapshots
 .soroban
 .stellar
 
+# Git worktrees (linked checkouts — never commit these)
+.worktrees/
+
 # Environment variables (do not commit secrets)
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Fluxapay solves this by enabling _USDC-in → fiat-out_ payments with a merchant
 - Manage customers & metadata
   •⁠ ⁠*Webhooks*
 - ⁠ payment.created ⁠, ⁠ payment.pending ⁠, ⁠ payment.confirmed ⁠, ⁠ payment.failed ⁠, ⁠ payment.settled ⁠
+- Also: `refund.*` and `dispute.*` lifecycle events
+- Full merchant guide (payloads, HMAC verification, retries, idempotency, examples): **[docs/webhooks.md](docs/webhooks.md)**
 
 ### No-Code / Low-Code
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,357 @@
+# FluxaPay Webhook Integration Guide
+
+This guide explains how merchants consume **off-chain webhook** notifications for payment lifecycle events. On-chain event catalogs live in [`docs/events.md`](events.md) and [`fluxapay/EVENTS.md`](../fluxapay/EVENTS.md). Webhooks are the REST-facing projection of those events for merchant backends.
+
+---
+
+## Overview
+
+When a payment (or refund/dispute) transitions state, FluxaPay’s off-chain indexer delivers an HTTPS `POST` to your registered webhook URL. You should:
+
+1. Verify the HMAC-SHA256 signature
+2. Deduplicate with `payment_id` (or the event’s primary id)
+3. Return `2xx` quickly; handle business logic asynchronously
+
+---
+
+## Event types
+
+### Payment lifecycle
+
+| Webhook event | Trigger | Typical on-chain source |
+|---------------|---------|-------------------------|
+| `payment.created` | Charge created | `PAYMENT/CREATED` |
+| `payment.pending` | Awaiting on-chain confirmation | payment still `Pending` |
+| `payment.confirmed` | Deposit verified | `PAYMENT/CONFIRMED` / verify |
+| `payment.failed` | Expired or failed | `PAYMENT/EXPIRED` / failed status |
+| `payment.settled` | Merchant settled | `PAYMENT/SETTLED` |
+
+### Refund events (`REFUND/*`)
+
+| Webhook event | Trigger | On-chain source |
+|---------------|---------|-----------------|
+| `refund.requested` | Refund filed | `REFUND/REQUESTED` |
+| `refund.processed` | Refund completed | `REFUND/PROCESSED` / `COMPLETED` |
+| `refund.rejected` | Refund rejected | `REFUND/REJECTED` |
+
+### Dispute events (`DISPUTE/*`)
+
+| Webhook event | Trigger | On-chain source |
+|---------------|---------|-----------------|
+| `dispute.created` | Dispute opened | `DISPUTE/CREATED` |
+| `dispute.reviewed` | Moved under review | `DISPUTE/REVIEWED` |
+| `dispute.resolved` | Resolution applied | `DISPUTE/RESOLVED` |
+| `dispute.rejected` | Dispute rejected | `DISPUTE/REJECTED` |
+| `dispute.escalated` | Deadline / escalation | `DISPUTE/ESCALATED` |
+| `dispute.batch_created` | Bulk filing result | `DISPUTE/BATCH_CREATED` |
+
+---
+
+## Payload schema
+
+All webhooks share a common envelope:
+
+```json
+{
+  "id": "evt_01HXYZ...",
+  "type": "payment.confirmed",
+  "created_at": 1710000000,
+  "api_version": "2024-01-01",
+  "data": {
+    "payment_id": "pay_abc123",
+    "merchant_id": "G...",
+    "amount": "10000000",
+    "currency": "USDC",
+    "status": "confirmed",
+    "metadata": {
+      "order_id": "ORD-9"
+    }
+  }
+}
+```
+
+### Field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique event delivery id (not the payment id) |
+| `type` | string | Event name (see tables above) |
+| `created_at` | number | Unix timestamp (seconds) |
+| `api_version` | string | Payload schema version |
+| `data.payment_id` | string | **Idempotency / dedup key** for payment events |
+| `data.merchant_id` | string | Merchant Stellar address |
+| `data.amount` | string | Amount in minor units (string to avoid JSON number precision issues) |
+| `data.currency` | string | e.g. `USDC` |
+| `data.status` | string | Current status snapshot |
+| `data.metadata` | object\|null | Merchant metadata from create |
+
+### Refund payload extras
+
+```json
+{
+  "type": "refund.processed",
+  "data": {
+    "refund_id": "ref_...",
+    "payment_id": "pay_...",
+    "amount": "5000000",
+    "status": "completed"
+  }
+}
+```
+
+Dedup key for refunds: prefer `refund_id`; fall back to `payment_id` + `type`.
+
+### Dispute payload extras
+
+```json
+{
+  "type": "dispute.created",
+  "data": {
+    "dispute_id": "dsp_...",
+    "payment_id": "pay_...",
+    "amount": "10000000",
+    "status": "open",
+    "reason": "Item not received"
+  }
+}
+```
+
+Dedup key for disputes: `dispute_id`.
+
+---
+
+## HMAC-SHA256 signature verification
+
+Every request includes:
+
+| Header | Description |
+|--------|-------------|
+| `X-FluxaPay-Signature` | Hex-encoded HMAC-SHA256 of `{timestamp}.{raw_body}` |
+| `X-FluxaPay-Timestamp` | Unix seconds when the webhook was signed |
+| `X-FluxaPay-Event` | Same as JSON `type` (convenience) |
+
+### Algorithm
+
+1. Read the **raw request body** (do not re-serialize JSON).
+2. Build the signed payload: `` `${timestamp}.${rawBody}` ``
+3. Compute `HMAC-SHA256(webhook_secret, signed_payload)` → hex digest.
+4. Compare to `X-FluxaPay-Signature` using a **constant-time** compare.
+5. Reject if `|now - timestamp| > 300` seconds (replay window).
+
+Your webhook secret is issued in the merchant dashboard (or sandbox env). Never log the secret.
+
+---
+
+## Retry policy
+
+If your endpoint does not return HTTP `2xx`:
+
+| Attempt | Delay before retry |
+|---------|--------------------|
+| 1 (initial) | immediate |
+| 2 | ~1s |
+| 3 | ~2s |
+| 4 (final) | ~4s |
+
+- **Max retries:** 3 retries after the first delivery (**4 total attempts**).
+- **Backoff:** exponential (base ~1s).
+- After exhaustion, the event is marked failed; you can replay from the dashboard or indexer.
+
+Return `200` as soon as the event is durably queued; do heavy work out-of-band.
+
+---
+
+## Idempotency
+
+Deliveries can repeat (retries, at-least-once semantics).
+
+**Recommended dedup key:** `payment_id` for payment events (as specified for merchant integrations). For refunds/disputes use `refund_id` / `dispute_id`, or composite `event_id` (`id` field) if you process many event types in one table.
+
+Pseudo-flow:
+
+```
+if already_processed(payment_id, type):
+    return 200
+process(event)
+mark_processed(payment_id, type)
+return 200
+```
+
+Store processed keys for at least 7 days.
+
+---
+
+## Mapping on-chain → webhook
+
+| On-chain `(namespace, action)` | Webhook `type` |
+|--------------------------------|----------------|
+| `PAYMENT/CREATED` | `payment.created` |
+| (indexer pending state) | `payment.pending` |
+| `PAYMENT/CONFIRMED` | `payment.confirmed` |
+| `PAYMENT/EXPIRED` / failed | `payment.failed` |
+| `PAYMENT/SETTLED` | `payment.settled` |
+| `REFUND/REQUESTED` | `refund.requested` |
+| `REFUND/PROCESSED` | `refund.processed` |
+| `REFUND/REJECTED` | `refund.rejected` |
+| `DISPUTE/CREATED` | `dispute.created` |
+| `DISPUTE/REVIEWED` | `dispute.reviewed` |
+| `DISPUTE/RESOLVED` | `dispute.resolved` |
+| `DISPUTE/REJECTED` | `dispute.rejected` |
+| `DISPUTE/ESCALATED` | `dispute.escalated` |
+| `DISPUTE/BATCH_CREATED` | `dispute.batch_created` |
+
+---
+
+## Node.js (Express) example
+
+```javascript
+const express = require("express");
+const crypto = require("crypto");
+
+const app = express();
+const WEBHOOK_SECRET = process.env.FLUXAPAY_WEBHOOK_SECRET;
+
+// Must capture raw body for HMAC
+app.post(
+  "/webhooks/fluxapay",
+  express.raw({ type: "application/json" }),
+  (req, res) => {
+    const signature = req.get("X-FluxaPay-Signature") || "";
+    const timestamp = req.get("X-FluxaPay-Timestamp") || "";
+    const rawBody = req.body.toString("utf8");
+
+    const age = Math.abs(Date.now() / 1000 - Number(timestamp));
+    if (!Number.isFinite(age) || age > 300) {
+      return res.status(401).send("stale timestamp");
+    }
+
+    const expected = crypto
+      .createHmac("sha256", WEBHOOK_SECRET)
+      .update(`${timestamp}.${rawBody}`)
+      .digest("hex");
+
+    const a = Buffer.from(signature, "utf8");
+    const b = Buffer.from(expected, "utf8");
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+      return res.status(401).send("invalid signature");
+    }
+
+    const event = JSON.parse(rawBody);
+    const dedupKey = event.data.payment_id || event.data.dispute_id || event.id;
+
+    // TODO: skip if dedupKey already processed
+    console.log("received", event.type, dedupKey);
+
+    res.status(200).json({ received: true });
+  }
+);
+
+app.listen(3000);
+```
+
+---
+
+## Python (FastAPI) example
+
+```python
+import hashlib
+import hmac
+import os
+import time
+
+from fastapi import FastAPI, Header, HTTPException, Request
+
+app = FastAPI()
+WEBHOOK_SECRET = os.environ["FLUXAPAY_WEBHOOK_SECRET"].encode()
+
+
+@app.post("/webhooks/fluxapay")
+async def fluxapay_webhook(
+    request: Request,
+    x_fluxapay_signature: str = Header(...),
+    x_fluxapay_timestamp: str = Header(...),
+):
+    raw = await request.body()
+    try:
+        ts = int(x_fluxapay_timestamp)
+    except ValueError as exc:
+        raise HTTPException(401, "bad timestamp") from exc
+
+    if abs(time.time() - ts) > 300:
+        raise HTTPException(401, "stale timestamp")
+
+    signed = f"{ts}.".encode() + raw
+    expected = hmac.new(WEBHOOK_SECRET, signed, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, x_fluxapay_signature):
+        raise HTTPException(401, "invalid signature")
+
+    event = await request.json()
+    payment_id = (event.get("data") or {}).get("payment_id")
+    # TODO: idempotent upsert keyed by payment_id (or event["id"])
+    return {"received": True, "payment_id": payment_id}
+```
+
+---
+
+## Testing with the subscription daemon
+
+[`scripts/subscription-daemon.js`](../scripts/subscription-daemon.js) polls due subscriptions and invokes `process_due_subscriptions`. Use it locally to generate recurring payment lifecycle traffic that your webhook stack can observe end-to-end.
+
+### Setup
+
+1. Copy `.env.example` → `.env` and set:
+
+   ```bash
+   STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+   CONTRACT_ID=C...
+   OPERATOR_SECRET=S...
+   POLL_INTERVAL_MS=60000
+   NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+   SUBSCRIPTION_INDEX_PATH=/tmp/fluxapay_subscriptions.json
+   ```
+
+2. Ensure an off-chain index (or the JSON fallback file) lists active subscriptions.
+
+3. Run:
+
+   ```bash
+   node scripts/subscription-daemon.js
+   ```
+
+4. Point your local Express/FastAPI webhook at a tunnel (e.g. ngrok) and register that URL in sandbox.
+
+5. When the daemon bills a subscription, expect `payment.created` → `payment.confirmed` → (optionally) `payment.settled` deliveries.
+
+### Manual signature check
+
+```bash
+BODY='{"id":"evt_test","type":"payment.created","created_at":1710000000,"api_version":"2024-01-01","data":{"payment_id":"pay_test","amount":"100"}}'
+TS=$(date +%s)
+SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$FLUXAPAY_WEBHOOK_SECRET" | awk '{print $2}')
+curl -X POST http://localhost:3000/webhooks/fluxapay \
+  -H "Content-Type: application/json" \
+  -H "X-FluxaPay-Timestamp: $TS" \
+  -H "X-FluxaPay-Signature: $SIG" \
+  -H "X-FluxaPay-Event: payment.created" \
+  -d "$BODY"
+```
+
+---
+
+## Security checklist
+
+- [ ] Verify HMAC on **raw** body
+- [ ] Enforce timestamp skew ≤ 5 minutes
+- [ ] Deduplicate with `payment_id` (or entity id)
+- [ ] Respond `2xx` only after durable accept
+- [ ] Rotate webhook secrets without downtime (accept dual secrets briefly)
+- [ ] Prefer HTTPS-only endpoints
+
+---
+
+## Related docs
+
+- [On-chain event catalog](events.md)
+- [Architecture & settlement webhooks](architecture.md)
+- [SEP-6 / SEP-24 anchor callbacks](sep6-sep24-anchor-integration.md)
+- [Local invoke recipes](local-invoke.md)

--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -597,3 +597,227 @@ fn test_resolve_dispute_with_only_operator_auth() {
     let refund = refund_client.get_refund(&refund_id);
     assert_eq!(refund.status, RefundStatus::Completed);
 }
+
+fn valid_evidence(env: &Env) -> String {
+    String::from_str(env, "f000000000000000000000000000000000")
+}
+
+fn setup_confirmed_payment_for_dispute(
+    env: &Env,
+    payment_client: &PaymentProcessorClient,
+    refund_client: &RefundManagerClient,
+    admin: &Address,
+    payment_id_text: &str,
+    amount: i128,
+) -> (Address, Address, String) {
+    let merchant = Address::generate(env);
+    let customer = Address::generate(env);
+    let payment_id = String::from_str(env, payment_id_text);
+
+    payment_client.grant_role(admin, &Symbol::new(env, "MERCHANT"), &merchant);
+    payment_client.create_payment(&create_payment_args(env, &payment_id, &merchant, amount));
+
+    let oracle = Address::generate(env);
+    payment_client.grant_role(admin, &Symbol::new(env, "ORACLE"), &oracle);
+    payment_client.verify_payment(
+        &oracle,
+        &payment_id,
+        &BytesN::from_array(env, &[9u8; 32]),
+        &customer,
+        &amount,
+    );
+
+    let token_address = env.as_contract(&refund_client.address, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::UsdcToken)
+            .unwrap()
+    });
+    let token_admin_client = token::StellarAssetClient::new(env, &token_address);
+    token_admin_client.mint(&customer, &1_000_000);
+    token_admin_client.mint(&merchant, &1_000_000);
+
+    refund_client.register_payment(&payment_id, &merchant, &amount, &Symbol::new(env, "USDC"));
+    (merchant, customer, payment_id)
+}
+
+#[test]
+fn test_batch_create_disputes_full_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, refund_client) = setup_contracts(&env);
+
+    let mut batch = soroban_sdk::vec![&env];
+    for i in 0..3u32 {
+        let pid = format!("batch_ok_{i}");
+        let (merchant, customer, payment_id) = setup_confirmed_payment_for_dispute(
+            &env,
+            &payment_client,
+            &refund_client,
+            &admin,
+            &pid,
+            1_000,
+        );
+        let _ = merchant;
+        batch.push_back(crate::CreateDisputeArgs {
+            payment_id,
+            amount: 500i128,
+            reason: String::from_str(&env, "bulk"),
+            evidence: valid_evidence(&env),
+            disputer: customer,
+            payout_splits: vec![&env],
+        });
+    }
+
+    let results = refund_client.batch_create_disputes(&batch, &20u32);
+    assert_eq!(results.len(), 3);
+    for r in results.iter() {
+        match r {
+            crate::DisputeBatchItemResult::Ok(_) => {}
+            crate::DisputeBatchItemResult::Err(code) => panic!("unexpected err {code}"),
+        }
+    }
+
+    assert!(env.events().all().iter().any(|(_, topics, _)| {
+        if topics.len() < 2 {
+            return false;
+        }
+        let ns: Result<Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        let name: Result<Symbol, _> = topics.get(1).unwrap().try_into_val(&env);
+        matches!(
+            (ns, name),
+            (Ok(a), Ok(b))
+                if a == Symbol::new(&env, "DISPUTE") && b == Symbol::new(&env, "BATCH_CREATED")
+        )
+    }));
+}
+
+#[test]
+fn test_batch_create_disputes_mixed_success_fail() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, refund_client) = setup_contracts(&env);
+
+    let (_m1, c1, pay1) = setup_confirmed_payment_for_dispute(
+        &env,
+        &payment_client,
+        &refund_client,
+        &admin,
+        "batch_mix_ok",
+        1_000,
+    );
+    let (_m2, c2, pay2) = setup_confirmed_payment_for_dispute(
+        &env,
+        &payment_client,
+        &refund_client,
+        &admin,
+        "batch_mix_bad",
+        1_000,
+    );
+
+    let batch = soroban_sdk::vec![
+        &env,
+        crate::CreateDisputeArgs {
+            payment_id: pay1,
+            amount: 500i128,
+            reason: String::from_str(&env, "ok"),
+            evidence: valid_evidence(&env),
+            disputer: c1,
+            payout_splits: vec![&env],
+        },
+        crate::CreateDisputeArgs {
+            payment_id: pay2,
+            amount: 0i128, // invalid → fail
+            reason: String::from_str(&env, "bad"),
+            evidence: valid_evidence(&env),
+            disputer: c2,
+            payout_splits: vec![&env],
+        },
+        crate::CreateDisputeArgs {
+            payment_id: String::from_str(&env, "missing_payment_xyz"),
+            amount: 100i128,
+            reason: String::from_str(&env, "missing"),
+            evidence: valid_evidence(&env),
+            disputer: Address::generate(&env),
+            payout_splits: vec![&env],
+        },
+    ];
+
+    let results = refund_client.batch_create_disputes(&batch, &20u32);
+    assert_eq!(results.len(), 3);
+    assert!(matches!(
+        results.get(0).unwrap(),
+        crate::DisputeBatchItemResult::Ok(_)
+    ));
+    assert!(matches!(
+        results.get(1).unwrap(),
+        crate::DisputeBatchItemResult::Err(_)
+    ));
+    assert!(matches!(
+        results.get(2).unwrap(),
+        crate::DisputeBatchItemResult::Err(_)
+    ));
+}
+
+#[test]
+fn test_batch_create_disputes_full_failure() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, _payment_client, refund_client) = setup_contracts(&env);
+
+    let batch = soroban_sdk::vec![
+        &env,
+        crate::CreateDisputeArgs {
+            payment_id: String::from_str(&env, "nope_1"),
+            amount: 100i128,
+            reason: String::from_str(&env, "x"),
+            evidence: valid_evidence(&env),
+            disputer: Address::generate(&env),
+            payout_splits: vec![&env],
+        },
+        crate::CreateDisputeArgs {
+            payment_id: String::from_str(&env, "nope_2"),
+            amount: -1i128,
+            reason: String::from_str(&env, "y"),
+            evidence: valid_evidence(&env),
+            disputer: Address::generate(&env),
+            payout_splits: vec![&env],
+        },
+    ];
+
+    let results = refund_client.batch_create_disputes(&batch, &20u32);
+    assert_eq!(results.len(), 2);
+    assert!(matches!(
+        results.get(0).unwrap(),
+        crate::DisputeBatchItemResult::Err(_)
+    ));
+    assert!(matches!(
+        results.get(1).unwrap(),
+        crate::DisputeBatchItemResult::Err(_)
+    ));
+}
+
+#[test]
+fn test_batch_create_disputes_rejects_oversized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, _payment_client, refund_client) = setup_contracts(&env);
+
+    let mut batch = soroban_sdk::vec![&env];
+    for i in 0..21u32 {
+        batch.push_back(crate::CreateDisputeArgs {
+            payment_id: String::from_str(&env, &format!("p{i}")),
+            amount: 1i128,
+            reason: String::from_str(&env, "r"),
+            evidence: valid_evidence(&env),
+            disputer: Address::generate(&env),
+            payout_splits: vec![&env],
+        });
+    }
+
+    let result = refund_client.try_batch_create_disputes(&batch, &20u32);
+    assert_eq!(result, Err(Ok(crate::Error::BatchTooLarge)));
+
+    let result2 = refund_client.try_batch_create_disputes(&soroban_sdk::vec![&env], &21u32);
+    assert_eq!(result2, Err(Ok(crate::Error::BatchTooLarge)));
+}

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -215,7 +215,7 @@ pub struct ArbitratorVote {
 }
 
 #[contracterror]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     PaymentNotFound = 404,
     RefundNotFound = 405,
@@ -294,6 +294,8 @@ pub enum Error {
     InvalidMemoId = 52,
     /// Issue #516: Payer address is not on the merchant's customer whitelist.
     PayerNotWhitelisted = 53,
+    /// Payment link has reached its configured max_uses limit.
+    LinkMaxUsesReached = 54,
 }
 
 #[contracttype]
@@ -323,6 +325,29 @@ pub struct CreatePaymentArgs {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Arguments for a single dispute in `batch_create_disputes` / `create_dispute`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateDisputeArgs {
+    pub payment_id: String,
+    pub amount: i128,
+    pub reason: String,
+    pub evidence: String,
+    pub disputer: Address,
+    pub payout_splits: Vec<SettlementSplit>,
+}
+
+/// Per-item outcome for `batch_create_disputes` (partial success allowed).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeBatchItemResult {
+    Ok(String),
+    Err(u32),
+}
+
+/// Hard cap for dispute batch size.
+pub const MAX_DISPUTE_BATCH: u32 = 20;
+
 pub struct SwapAndPayArgs {
     pub payer: Address,
     pub payment_id: String,
@@ -410,6 +435,19 @@ pub struct VoteTally {
     /// Number of arbitrators who have voted.
     pub vote_count: u32,
 }
+
+/// Record of a single admin treasury withdrawal.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TreasuryWithdrawal {
+    pub amount: i128,
+    pub destination: Address,
+    pub admin: Address,
+    pub withdrawn_at: u64,
+}
+
+/// Maximum number of withdrawal records retained in `TreasuryWithdrawalHistory`.
+pub const TREASURY_WITHDRAWAL_HISTORY_CAP: u32 = 100;
 
 /// Issue #168: Fee split configuration for refund fees.
 #[contracttype]
@@ -687,6 +725,8 @@ pub enum DataKey {
     /// Admin-managed reusable fee-waiver code registry for per-payment promotions.
     /// Keyed by the code string itself.
     FeeWaiverCode(String),
+    /// Paginated log of treasury withdrawals (newest-first, capped at 100).
+    TreasuryWithdrawalHistory,
 }
 
 /// Default initial contract version string.
@@ -1266,6 +1306,46 @@ impl RefundManager {
             .unwrap_or(0)
     }
 
+    /// Append a withdrawal record, retaining only the newest
+    /// `TREASURY_WITHDRAWAL_HISTORY_CAP` entries (newest-first).
+    fn record_treasury_withdrawal(env: &Env, record: TreasuryWithdrawal) {
+        let key = DataKey::TreasuryWithdrawalHistory;
+        let mut history: Vec<TreasuryWithdrawal> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| vec![env]);
+        history.push_front(record);
+        while history.len() > TREASURY_WITHDRAWAL_HISTORY_CAP {
+            history.pop_back();
+        }
+        env.storage().persistent().set(&key, &history);
+    }
+
+    /// Return a page of treasury withdrawal history (newest-first).
+    /// `offset` skips the first N records; `limit` caps the page size (max 100).
+    pub fn get_treasury_withdrawal_history(
+        env: Env,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<TreasuryWithdrawal> {
+        let history: Vec<TreasuryWithdrawal> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TreasuryWithdrawalHistory)
+            .unwrap_or_else(|| vec![&env]);
+        let page_limit = limit.min(TREASURY_WITHDRAWAL_HISTORY_CAP);
+        let mut page: Vec<TreasuryWithdrawal> = vec![&env];
+        let mut i = offset;
+        while i < history.len() && page.len() < page_limit {
+            if let Some(item) = history.get(i) {
+                page.push_back(item);
+            }
+            i = i.saturating_add(1);
+        }
+        page
+    }
+
     pub fn withdraw_treasury(
         env: Env,
         admin: Address,
@@ -1301,9 +1381,19 @@ impl RefundManager {
 
         token_client.transfer(&contract_address, &destination, &amount);
 
+        Self::record_treasury_withdrawal(
+            &env,
+            TreasuryWithdrawal {
+                amount,
+                destination: destination.clone(),
+                admin: admin.clone(),
+                withdrawn_at: env.ledger().timestamp(),
+            },
+        );
+
         env.events().publish(
             (Symbol::new(&env, "TREASURY"), Symbol::new(&env, "WITHDRAWN")),
-            (amount, destination),
+            (amount, destination.clone()),
         );
 
         Ok(())
@@ -1724,6 +1814,83 @@ impl RefundManager {
         payout_splits: Vec<SettlementSplit>,
     ) -> Result<String, Error> {
         disputer.require_auth();
+        Self::create_dispute_inner(
+            &env,
+            payment_id,
+            amount,
+            reason,
+            evidence,
+            disputer,
+            payout_splits,
+        )
+    }
+
+    /// Batch-create disputes for marketplace bulk filing.
+    ///
+    /// Processes up to `max_batch` items (hard cap 20). Each item is handled
+    /// identically to `create_dispute`; failures do not revert successes.
+    /// Bonds are deducted only for successful disputes.
+    /// Emits `DISPUTE/BATCH_CREATED` with `(success_count, fail_count)`.
+    pub fn batch_create_disputes(
+        env: Env,
+        disputes: Vec<CreateDisputeArgs>,
+        max_batch: u32,
+    ) -> Result<Vec<DisputeBatchItemResult>, Error> {
+        let effective_max = max_batch.min(MAX_DISPUTE_BATCH);
+        if max_batch > MAX_DISPUTE_BATCH || disputes.len() > effective_max {
+            return Err(Error::BatchTooLarge);
+        }
+
+        let mut results: Vec<DisputeBatchItemResult> = vec![&env];
+        let mut success_count: u32 = 0;
+        let mut fail_count: u32 = 0;
+        let mut total_bond_deducted: i128 = 0;
+
+        for args in disputes.iter() {
+            args.disputer.require_auth();
+            match Self::create_dispute_inner(
+                &env,
+                args.payment_id.clone(),
+                args.amount,
+                args.reason.clone(),
+                args.evidence.clone(),
+                args.disputer.clone(),
+                args.payout_splits.clone(),
+            ) {
+                Ok(dispute_id) => {
+                    success_count = success_count.saturating_add(1);
+                    // Each successful dispute locks 2x DISPUTE_BOND_AMOUNT (disputer + merchant).
+                    total_bond_deducted = total_bond_deducted
+                        .saturating_add(DISPUTE_BOND_AMOUNT.saturating_mul(2));
+                    results.push_back(DisputeBatchItemResult::Ok(dispute_id));
+                }
+                Err(e) => {
+                    fail_count = fail_count.saturating_add(1);
+                    results.push_back(DisputeBatchItemResult::Err(e as u32));
+                }
+            }
+        }
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "DISPUTE"),
+                Symbol::new(&env, "BATCH_CREATED"),
+            ),
+            (success_count, fail_count, total_bond_deducted),
+        );
+
+        Ok(results)
+    }
+
+    fn create_dispute_inner(
+        env: &Env,
+        payment_id: String,
+        amount: i128,
+        reason: String,
+        evidence: String,
+        disputer: Address,
+        payout_splits: Vec<SettlementSplit>,
+    ) -> Result<String, Error> {
 
         // Issue #404: Validate payment_id format
         if !utils::validate_id(&payment_id) {
@@ -3886,12 +4053,105 @@ impl PaymentProcessor {
         Ok(())
     }
 
-    /// Return the accumulated treasury balance collected via settlement fees.
+    /// Return the accumulated treasury balance collected via settlement fees
+    /// and platform fees (when no custom fee_recipient).
     pub fn get_treasury_balance(env: Env) -> i128 {
         env.storage()
             .persistent()
             .get(&DataKey::TreasuryBalance)
             .unwrap_or(0)
+    }
+
+    fn record_treasury_withdrawal(env: &Env, record: TreasuryWithdrawal) {
+        let key = DataKey::TreasuryWithdrawalHistory;
+        let mut history: Vec<TreasuryWithdrawal> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| vec![env]);
+        history.push_front(record);
+        while history.len() > TREASURY_WITHDRAWAL_HISTORY_CAP {
+            history.pop_back();
+        }
+        env.storage().persistent().set(&key, &history);
+    }
+
+    /// Return a page of treasury withdrawal history (newest-first).
+    pub fn get_treasury_withdrawal_history(
+        env: Env,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<TreasuryWithdrawal> {
+        let history: Vec<TreasuryWithdrawal> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TreasuryWithdrawalHistory)
+            .unwrap_or_else(|| vec![&env]);
+        let page_limit = limit.min(TREASURY_WITHDRAWAL_HISTORY_CAP);
+        let mut page: Vec<TreasuryWithdrawal> = vec![&env];
+        let mut i = offset;
+        while i < history.len() && page.len() < page_limit {
+            if let Some(item) = history.get(i) {
+                page.push_back(item);
+            }
+            i = i.saturating_add(1);
+        }
+        page
+    }
+
+    /// Admin withdrawal of accumulated treasury fees. Emits `TREASURY/WITHDRAWN`
+    /// with `(amount, destination)` and appends to the paginated history log.
+    pub fn withdraw_treasury(
+        env: Env,
+        admin: Address,
+        amount: i128,
+        destination: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let treasury_balance = Self::get_treasury_balance(env.clone());
+        if amount > treasury_balance {
+            return Err(Error::InsufficientTreasuryBalance);
+        }
+
+        let usdc_token_address: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UsdcToken)
+            .ok_or(Error::Unauthorized)?;
+        let token_client = token::TokenClient::new(&env, &usdc_token_address);
+        let contract_address = env.current_contract_address();
+
+        env.storage().persistent().set(
+            &DataKey::TreasuryBalance,
+            &treasury_balance.saturating_sub(amount),
+        );
+
+        token_client.transfer(&contract_address, &destination, &amount);
+
+        Self::record_treasury_withdrawal(
+            &env,
+            TreasuryWithdrawal {
+                amount,
+                destination: destination.clone(),
+                admin: admin.clone(),
+                withdrawn_at: env.ledger().timestamp(),
+            },
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "TREASURY"), Symbol::new(&env, "WITHDRAWN")),
+            (amount, destination),
+        );
+
+        Ok(())
     }
 
     /// Admin-only: register a reusable fee-waiver code for per-payment zero-fee
@@ -5769,14 +6029,6 @@ impl PaymentProcessor {
 
                     let net_merchant_amount = net_after_settlement_fee.saturating_sub(actual_fee);
 
-                    // Get fee recipient
-                    let fee_recipient: Address = if let Some(custom_recipient) = &fee_config.fee_recipient {
-                        custom_recipient.clone()
-                    } else {
-                        // Default to admin if no custom recipient
-                        AccessControl::get_admin(&env).unwrap_or_else(|| env.current_contract_address())
-                    };
-
                     // Transfer using the resolved settlement token (if configured)
                     if let Some(ref settlement_token) = settlement_token {
                         let token_client = token::TokenClient::new(&env, settlement_token);
@@ -5786,12 +6038,33 @@ impl PaymentProcessor {
                         if net_merchant_amount > 0 {
                             let _ = token_client.try_transfer(&from, &payment.merchant_id, &net_merchant_amount);
                         }
-
-                        // Transfer fee to fee_recipient
-                        if actual_fee > 0 {
-                            let _ = token_client.try_transfer(&from, &fee_recipient, &actual_fee);
-                        }
                     }
+
+                    // Platform fee: custom fee_recipient receives a transfer; otherwise
+                    // credit DataKey::TreasuryBalance (unified treasury accounting).
+                    let fee_recipient: Address = if let Some(custom_recipient) = &fee_config.fee_recipient {
+                        if actual_fee > 0 {
+                            if let Some(ref settlement_token) = settlement_token {
+                                let token_client = token::TokenClient::new(&env, settlement_token);
+                                let from = env.current_contract_address();
+                                let _ = token_client.try_transfer(&from, custom_recipient, &actual_fee);
+                            }
+                        }
+                        custom_recipient.clone()
+                    } else {
+                        if actual_fee > 0 {
+                            let current_treasury: i128 = env
+                                .storage()
+                                .persistent()
+                                .get::<DataKey, i128>(&DataKey::TreasuryBalance)
+                                .unwrap_or(0);
+                            env.storage().persistent().set(
+                                &DataKey::TreasuryBalance,
+                                &current_treasury.saturating_add(actual_fee),
+                            );
+                        }
+                        env.current_contract_address()
+                    };
 
                     // Emit FEE_COLLECTED event (merchant-level fee)
                     env.events().publish(
@@ -5905,9 +6178,21 @@ impl PaymentProcessor {
             }
         }
 
-        // Transfer platform fee to fee_recipient using the resolved settlement token (if configured)
+        // Platform fee: when the registry returns the contract itself as recipient
+        // (no custom fee_recipient), credit TreasuryBalance. Otherwise transfer out.
         if platform_fee > 0 {
-            if let Some(ref settlement_token) = settlement_token {
+            let contract_addr = env.current_contract_address();
+            if fee_recipient == contract_addr {
+                let current_treasury: i128 = env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, i128>(&DataKey::TreasuryBalance)
+                    .unwrap_or(0);
+                env.storage().persistent().set(
+                    &DataKey::TreasuryBalance,
+                    &current_treasury.saturating_add(platform_fee),
+                );
+            } else if let Some(ref settlement_token) = settlement_token {
                 let token_client = token::TokenClient::new(&env, settlement_token);
                 let from = env.current_contract_address();
                 let _ = token_client.try_transfer(&from, &fee_recipient, &platform_fee);

--- a/fluxapay/src/payment_link.rs
+++ b/fluxapay/src/payment_link.rs
@@ -247,7 +247,7 @@ impl PaymentLinkManager {
 
         if let Some(max_uses) = link.max_uses {
             if link.use_count >= max_uses {
-                return Err(crate::Error::PaymentAlreadyProcessed);
+                return Err(crate::Error::LinkMaxUsesReached);
             }
         }
 
@@ -294,12 +294,30 @@ impl PaymentLinkManager {
             amount
         };
 
-        link.use_count += 1;
+        // Atomic read-check-increment: use_count was checked above against the
+        // in-memory snapshot; the single storage write below commits the bump
+        // in the same transaction (Soroban tx isolation prevents mid-tx races).
+        link.use_count = link.use_count.saturating_add(1);
+        let hit_max_uses = link
+            .max_uses
+            .map(|m| link.use_count == m)
+            .unwrap_or(false);
+
         // Accumulate revenue from this payment.
         link.total_revenue = link.total_revenue.saturating_add(resolved_amount);
         env.storage()
             .persistent()
             .set(&LinkDataKey::Link(link_id.clone()), &link);
+
+        if hit_max_uses {
+            env.events().publish(
+                (
+                    Symbol::new(&env, "LINK"),
+                    Symbol::new(&env, "MAX_USES_REACHED"),
+                ),
+                (link_id.clone(), link.use_count, link.max_uses),
+            );
+        }
 
         // Issue #111: If direct_transfer is true, transfer funds directly to the merchant,
         // bypassing the escrow/platform wallet.

--- a/fluxapay/src/payment_link_test.rs
+++ b/fluxapay/src/payment_link_test.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
-    token, vec, Address, BytesN, Env, Map, String, Symbol,
+    token, vec, Address, BytesN, Env, Map, String, Symbol, TryIntoVal,
 };
 
 fn setup_payment_link(env: &Env) -> (Address, PaymentLinkManagerClient<'_>) {
@@ -286,7 +286,6 @@ fn test_verify_batch_empty_input_returns_empty_vec() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #14)")]
 fn test_max_uses() {
     let env = Env::default();
     env.mock_all_auths();
@@ -308,8 +307,84 @@ fn test_max_uses() {
     );
 
     client.use_link(&payer, &link_id, &100i128, &None);
-    // Should fail on second use
-    client.use_link(&payer, &link_id, &100i128, &None);
+    let link = client.get_link(&link_id);
+    assert_eq!(link.use_count, 1);
+
+    // Should fail on second use with LinkMaxUsesReached
+    let result = client.try_use_link(&payer, &link_id, &100i128, &None);
+    assert_eq!(result, Err(Ok(crate::Error::LinkMaxUsesReached)));
+}
+
+#[test]
+fn test_max_uses_exact_accepted_and_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (merchant, client) = setup_payment_link(&env);
+    let payer = Address::generate(&env);
+
+    let link_id = String::from_str(&env, "exact_max_link");
+    client.create_link(
+        &merchant,
+        &link_id,
+        &Some(50i128),
+        &Symbol::new(&env, "USDC"),
+        &String::from_str(&env, "Exact"),
+        &None,
+        &Some(2),
+        &false,
+        &None,
+        &MaybeFiatConfig::None,
+    );
+
+    client.use_link(&payer, &link_id, &50i128, &None);
+    assert_eq!(client.get_link(&link_id).use_count, 1);
+
+    client.use_link(&payer, &link_id, &50i128, &None);
+    assert_eq!(client.get_link(&link_id).use_count, 2);
+
+    let emitted = env.events().all().iter().any(|(_, topics, _)| {
+        if topics.len() < 2 {
+            return false;
+        }
+        let t0: Result<Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        let t1: Result<Symbol, _> = topics.get(1).unwrap().try_into_val(&env);
+        matches!(
+            (t0, t1),
+            (Ok(a), Ok(b))
+                if a == Symbol::new(&env, "LINK") && b == Symbol::new(&env, "MAX_USES_REACHED")
+        )
+    });
+    assert!(emitted, "LINK/MAX_USES_REACHED must fire when final use is consumed");
+
+    let rejected = client.try_use_link(&payer, &link_id, &50i128, &None);
+    assert_eq!(rejected, Err(Ok(crate::Error::LinkMaxUsesReached)));
+}
+
+#[test]
+fn test_unlimited_link_never_blocked_by_max_uses() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (merchant, client) = setup_payment_link(&env);
+    let payer = Address::generate(&env);
+
+    let link_id = String::from_str(&env, "unlimited_link");
+    client.create_link(
+        &merchant,
+        &link_id,
+        &Some(25i128),
+        &Symbol::new(&env, "USDC"),
+        &String::from_str(&env, "Open"),
+        &None,
+        &None, // unlimited
+        &false,
+        &None,
+        &MaybeFiatConfig::None,
+    );
+
+    for _ in 0..5 {
+        client.use_link(&payer, &link_id, &25i128, &None);
+    }
+    assert_eq!(client.get_link(&link_id).use_count, 5);
 }
 
 // -- Issue #111: Direct-to-Merchant Payment Flow ------------------------------

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -4191,3 +4191,182 @@ fn test_settle_payment_fee_split_rounding_dust_to_treasury() {
     assert_eq!(treasury_bal, 67i128);
     assert_eq!(dev_bal + treasury_bal, 100i128, "All fee tokens must be accounted for");
 }
+
+// =============================================================================
+// Treasury fee unification — settlement + refund fees + withdrawal history
+// =============================================================================
+
+#[test]
+fn test_settlement_fee_accumulates_in_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_payment_processor(&env);
+
+    client.set_fee_rate(&admin, &200i128); // 2%
+    let payment_id = String::from_str(&env, "treasury_settle_accum");
+    let amount = 10_000i128;
+    make_confirmed_payment(&env, &client, &admin, &payment_id, amount);
+
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_settlement_operator(&env), &operator);
+    let splits = vec![
+        &env,
+        SettlementSplit {
+            recipient: Address::generate(&env),
+            amount: 9_800i128,
+        },
+    ];
+    client.settle_payment(&operator, &payment_id, &splits);
+
+    assert_eq!(client.get_treasury_balance(), 200i128);
+}
+
+#[test]
+fn test_refund_fee_accumulates_in_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client, _usdc) = setup_refund_manager_with_token(&env);
+
+    let payment_id = String::from_str(&env, "treasury_refund_accum");
+    let merchant_id = Address::generate(&env);
+    let requester = Address::generate(&env);
+    client.register_payment(
+        &payment_id,
+        &merchant_id,
+        &10_000i128,
+        &Symbol::new(&env, "USDC"),
+    );
+    let refund_id = client.create_refund(
+        &payment_id,
+        &1_000i128,
+        &String::from_str(&env, "reason"),
+        &requester,
+    );
+    let operator = Address::generate(&env);
+    client.grant_role(&_admin, &role_settlement_operator(&env), &operator);
+    client.process_refund(&operator, &refund_id);
+
+    // Default refund fee 100 bps of 1000 = 10
+    assert_eq!(client.get_treasury_balance(), 10i128);
+}
+
+#[test]
+fn test_platform_fee_without_custom_recipient_credits_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let payment_contract = env.register(PaymentProcessor, ());
+    let registry_contract = env.register(crate::merchant_registry::MerchantRegistry, ());
+    let payment_client = PaymentProcessorClient::new(&env, &payment_contract);
+    let registry_client =
+        crate::merchant_registry::MerchantRegistryClient::new(&env, &registry_contract);
+
+    let admin = Address::generate(&env);
+    payment_client.initialize_payment_processor(&admin);
+    registry_client.initialize(&admin);
+    payment_client.set_merchant_registry_address(&admin, &registry_contract);
+
+    let token_id = setup_and_mint_token(&env, &payment_contract, 1_000_000i128);
+    env.as_contract(&payment_contract, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::UsdcToken, &token_id);
+    });
+
+    let merchant = Address::generate(&env);
+    payment_client.grant_role(&admin, &role_merchant(&env), &merchant);
+
+    let fee_config = crate::merchant_registry::FeeConfig {
+        platform_fee_bps: 100, // 1%
+        fixed_fee: 0,
+        fee_recipient: None, // → TreasuryBalance
+    };
+    registry_client.register_merchant(
+        &merchant,
+        &String::from_str(&env, "Fee Merchant"),
+        &String::from_str(&env, "USDC"),
+        &None::<Address>,
+        &None::<String>,
+        &Some(fee_config),
+    );
+    registry_client.set_kyc_tier_with_signature(
+        &admin,
+        &merchant,
+        &crate::merchant_registry::KycTier::Full,
+        &Some(String::from_str(&env, "sig")),
+    );
+
+    let payment_id = String::from_str(&env, "plat_fee_treasury");
+    let amount = 10_000i128;
+    let args = create_payment_args(&env, &payment_id, &merchant, amount);
+    payment_client.create_payment(&args);
+
+    let oracle = Address::generate(&env);
+    payment_client.grant_role(&admin, &role_oracle(&env), &oracle);
+    payment_client.verify_payment(
+        &oracle,
+        &payment_id,
+        &BytesN::<32>::random(&env),
+        &Address::generate(&env),
+        &amount,
+    );
+
+    let operator = Address::generate(&env);
+    payment_client.grant_role(&admin, &role_settlement_operator(&env), &operator);
+    payment_client.settle_payment(&operator, &payment_id, &vec![&env]);
+
+    // 1% of 10_000 = 100 credited to treasury (no custom recipient)
+    assert_eq!(payment_client.get_treasury_balance(), 100i128);
+}
+
+#[test]
+fn test_withdraw_treasury_reduces_balance_and_logs_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client, usdc_token) = setup_refund_manager_with_token(&env);
+    let token_client = token::StellarAssetClient::new(&env, &usdc_token);
+
+    let merchant_id = Address::generate(&env);
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_settlement_operator(&env), &operator);
+
+    let payment_id = String::from_str(&env, "withdraw_hist_pay");
+    let requester = Address::generate(&env);
+    client.register_payment(
+        &payment_id,
+        &merchant_id,
+        &50_000i128,
+        &Symbol::new(&env, "USDC"),
+    );
+    let refund_id = client.create_refund(
+        &payment_id,
+        &10_000i128,
+        &String::from_str(&env, "reason"),
+        &requester,
+    );
+    client.process_refund(&operator, &refund_id);
+    // fee = 100 bps * 10000 = 100
+    assert_eq!(client.get_treasury_balance(), 100i128);
+
+    let destination = Address::generate(&env);
+    let starting = token::TokenClient::new(&env, &usdc_token).balance(&destination);
+    client.withdraw_treasury(&admin, &40i128, &destination);
+
+    assert_eq!(client.get_treasury_balance(), 60i128);
+    assert_eq!(
+        token::TokenClient::new(&env, &usdc_token).balance(&destination),
+        starting + 40
+    );
+
+    let history = client.get_treasury_withdrawal_history(&0u32, &10u32);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().amount, 40i128);
+    assert_eq!(history.get(0).unwrap().destination, destination);
+
+    // Insufficient withdrawal fails and does not change balance
+    let result = client.try_withdraw_treasury(&admin, &61i128, &destination);
+    assert_eq!(result, Err(Ok(Error::InsufficientTreasuryBalance)));
+    assert_eq!(client.get_treasury_balance(), 60i128);
+
+    let _ = token_client; // silence unused if only StellarAssetClient needed above
+}


### PR DESCRIPTION
Task 1 — docs/webhooks
Commit title: docs: add webhook integration guide for payment and refund events

PR description:

## Summary
- Add `docs/webhooks.md` covering merchant webhook consumption for payment, refund, and dispute lifecycle events
- Document payload envelope, HMAC-SHA256 verification, retry policy (3 retries / exponential backoff), and `payment_id` idempotency
- Include Node.js (Express) and Python (FastAPI) receiver examples
- Document `REFUND/*` and `DISPUTE/*` webhook event types and on-chain → webhook mapping
- Link the guide from README under the Webhooks section
- Include testing notes with `scripts/subscription-daemon.js`
## Test plan
- [ ] Review `docs/webhooks.md` for accuracy vs on-chain event names in `docs/events.md`
- [ ] Confirm README Webhooks section links to `docs/webhooks.md`
- [ ] Spot-check Express/FastAPI HMAC examples against the documented signed-payload format
Task 2 — feat/treasury
Commit title: feat(treasury): unify settlement and refund fee accumulation in TreasuryBalance

PR description:

## Summary
- Credit `DataKey::TreasuryBalance` for platform fees from `settle_payment` when no custom `fee_recipient` is set (FeeConfig path + registry platform-fee path)
- Keep existing settlement-fee (`SettlementFeeRate`) and refund-fee accumulation on the same treasury balance key
- Extend `withdraw_treasury` to emit `TREASURY/WITHDRAWN` with `(amount, destination)` and append to paginated `DataKey::TreasuryWithdrawalHistory` (cap 100, newest-first)
- Add `get_treasury_withdrawal_history(offset, limit)` on RefundManager and PaymentProcessor
- Unit tests: settlement fee accumulates, refund fee accumulates, platform fee without custom recipient credits treasury, withdrawal reduces balance + logs history, over-withdraw fails
## Test plan
- [ ] `cargo test -p fluxapay test_settlement_fee_accumulates_in_treasury`
- [ ] `cargo test -p fluxapay test_refund_fee_accumulates_in_treasury`
- [ ] `cargo test -p fluxapay test_platform_fee_without_custom_recipient_credits_treasury`
- [ ] `cargo test -p fluxapay test_withdraw_treasury_reduces_balance_and_logs_history`
- [ ] Confirm custom `fee_recipient` still receives a direct transfer (not treasury credit)
Task 3 — feat/batch-disputes
Commit title: feat(dispute): add batch_create_disputes for bulk marketplace filing

PR description:

## Summary
- Add `batch_create_disputes(disputes, max_batch)` with hard max of 20 (`MAX_DISPUTE_BATCH`)
- Return `Vec<DisputeBatchItemResult>` (`Ok(dispute_id)` / `Err(error_code)`) so partial failures do not revert successes
- Process each item via the same logic as `create_dispute` (`create_dispute_inner`)
- Bonds deducted only for successful disputes; emit `DISPUTE/BATCH_CREATED` with success/fail counts (and total bond locked)
- Return `Error::BatchTooLarge` when batch or `max_batch` exceeds 20
- Unit tests: full success, mixed success/fail, full failure, oversized batch
## Test plan
- [ ] `cargo test -p fluxapay --features contract-refund-manager test_batch_create_disputes_full_success`
- [ ] `cargo test -p fluxapay --features contract-refund-manager test_batch_create_disputes_mixed_success_fail`
- [ ] `cargo test -p fluxapay --features contract-refund-manager test_batch_create_disputes_full_failure`
- [ ] `cargo test -p fluxapay --features contract-refund-manager test_batch_create_disputes_rejects_oversized`
- [ ] Confirm single `create_dispute` still works unchanged
Task 4 — fix/link-max-uses
Commit title: fix(payment-link): ensure atomic use_count increment to prevent race condition

PR description:

## Summary
- Enforce `max_uses` in `use_link` with a single-transaction read → check → increment → storage write
- Return new `Error::LinkMaxUsesReached` when `use_count >= max_uses`
- Emit `LINK/MAX_USES_REACHED` when the final allowed use is consumed
- `get_link` continues to reflect accurate `use_count`
- Unit tests: exact max accepted + event, max+1 rejected, unlimited (`None`) never blocked
## Test plan
- [ ] `cargo test -p fluxapay --features contract-payment-link test_max_uses`
- [ ] `cargo test -p fluxapay --features contract-payment-link test_max_uses_exact_accepted_and_emits_event`
- [ ] `cargo test -p fluxapay --features contract-payment-link test_unlimited_link_never_blocked_by_max_uses`
- [ ] Confirm `get_link` `use_count` matches successful uses

closes #465 
closes #472 
closes #474 
closes #477