### PR TITLE
security: dispute rate limits, refund reentrancy locks, evidence CID,…

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -190,6 +190,25 @@ The `FXOracle` contract (`fluxapay/src/fx_oracle.rs`) provides exchange rates us
 
 ---
 
+## 🔒 Refund Reentrancy Protection
+
+`process_refund` / `process_refund_internal` follow the **checks → effects → interactions** pattern to prevent double-refund via malicious token callbacks or nested cross-contract calls:
+
+1. **Checks** — auth, role, refund exists, status is `Pending`, not expired.
+2. **Effects** — set `refund.status = Completed` and persist under `DataKey::Refund` *before* any token transfer.
+3. **Interactions** — call `token::transfer` only after effects are committed.
+
+### Explicit locks
+
+| Lock | Scope | Behavior |
+|------|-------|----------|
+| `DataKey::ReentrancyLock` | Contract-wide | Set for the duration of `process_refund_internal` / settle paths; cleared via `Drop` guard. |
+| `DataKey::RefundLock(refund_id)` | Per refund ID | Set while processing that refund; concurrent/nested calls for the same ID return `Error::Reentrancy`. |
+
+A second `process_refund` for an already-completed refund returns `RefundAlreadyProcessed`. `resolve_dispute_with_refund` persists dispute resolution effects before returning dispute bonds.
+
+---
+
 ## 🤝 Responsible Disclosure Commitment
 
 We commit to:

--- a/docs/local-invoke.md
+++ b/docs/local-invoke.md
@@ -338,9 +338,32 @@ stellar contract invoke \
   --payment_id "inv_20260329_001" \
   --amount 1000000000 \
   --reason "Item not received" \
-  --evidence "Order #12345 shows no delivery confirmation" \
+  --evidence "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG" \
   --disputer $TEST_CUSTOMER_ADDRESS
 ```
+
+#### Evidence format (IPFS CID)
+
+When `require_evidence_cid` is enabled (default), non-empty `--evidence` must be a valid IPFS multihash:
+
+| Format | Rule | Example |
+|--------|------|---------|
+| CIDv0 | Starts with `Qm`, exactly 46 characters | `QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG` |
+| CIDv1 | Starts with `bafy` (or `BAFY` / `f…`), length ≥ 59 (or ≥ 34 for hex `f`) | `bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi` |
+
+Empty evidence is always allowed. For local/testnet convenience, disable enforcement:
+
+```bash
+stellar contract invoke \
+  --id $REFUND_MANAGER_ID \
+  --network testnet \
+  --source $ADMIN_ADDRESS \
+  -- set_require_evidence_cid \
+  --admin $ADMIN_ADDRESS \
+  --require_cid false
+```
+
+Invalid non-empty evidence returns `InvalidEvidenceFormat`.
 
 #### Expected Output
 
@@ -357,6 +380,8 @@ Returns the new dispute ID:
 | `PaymentAlreadyProcessed` | Payment is not in `Confirmed` state | Only confirmed payments can be disputed |
 | `InvalidAmount` | Amount ≤ 0 or exceeds payment amount | Use a positive amount within the original payment amount |
 | `RefundExceedsPayment` | Combined disputes + refunds exceed payment | Reduce dispute amount |
+| `InvalidEvidenceFormat` | Evidence is not a CIDv0/CIDv1 IPFS multihash | Pass a CID or disable `require_evidence_cid` |
+| `DisputeRateLimitExceeded` | Too many open disputes for payer or global hourly cap | Wait, resolve open disputes, or ask admin to adjust limits |
 
 ---
 

--- a/fluxapay/src/dispute_test.rs
+++ b/fluxapay/src/dispute_test.rs
@@ -22,6 +22,9 @@ fn setup_contracts(env: &Env) -> (Address, PaymentProcessorClient<'_>, RefundMan
     let token_admin_client = token::StellarAssetClient::new(env, &usdc_token);
     token_admin_client.mint(&refund_manager, &1_000_000_000_000i128);
 
+    // Existing suite uses free-form evidence; CID enforcement is covered by dedicated tests.
+    refund_client.set_require_evidence_cid(&admin, &false);
+
     payment_client.initialize_payment_processor(&admin);
 
     (admin, payment_client, refund_client)
@@ -596,4 +599,291 @@ fn test_resolve_dispute_with_only_operator_auth() {
 
     let refund = refund_client.get_refund(&refund_id);
     assert_eq!(refund.status, RefundStatus::Completed);
+}
+
+const VALID_CID_V0: &str = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+const VALID_CID_V1: &str = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+
+fn setup_confirmed_payment_for_dispute<'a>(
+    env: &'a Env,
+    payment_id_text: &str,
+    amount: i128,
+) -> (
+    Address,
+    Address,
+    Address,
+    PaymentProcessorClient<'a>,
+    RefundManagerClient<'a>,
+    String,
+) {
+    let (admin, payment_client, refund_client) = setup_contracts(env);
+    let merchant = Address::generate(env);
+    let customer = Address::generate(env);
+    let payment_id = String::from_str(env, payment_id_text);
+
+    payment_client.grant_role(&admin, &Symbol::new(env, "MERCHANT"), &merchant);
+    payment_client.create_payment(&create_payment_args(env, &payment_id, &merchant, amount));
+
+    let oracle = Address::generate(env);
+    payment_client.grant_role(&admin, &Symbol::new(env, "ORACLE"), &oracle);
+    payment_client.verify_payment(
+        &oracle,
+        &payment_id,
+        &BytesN::from_array(env, &[7u8; 32]),
+        &customer,
+        &amount,
+    );
+
+    let token_address = env.as_contract(&refund_client.address, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::UsdcToken)
+            .unwrap()
+    });
+    let token_admin_client = token::StellarAssetClient::new(env, &token_address);
+    token_admin_client.mint(&customer, &10_000_000);
+    token_admin_client.mint(&merchant, &10_000_000);
+
+    refund_client.register_payment(&payment_id, &merchant, &amount, &Symbol::new(env, "USDC"));
+
+    (admin, merchant, customer, payment_client, refund_client, payment_id)
+}
+
+#[test]
+fn test_dispute_rate_limit_sixth_open_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _merchant, customer, payment_client, refund_client, _) =
+        setup_confirmed_payment_for_dispute(&env, "rl_base", 100i128);
+    // Raise global hourly so we only hit the per-payer open cap.
+    refund_client.set_dispute_rate_limits(&admin, &5u32, &1000u32);
+
+    for i in 0..5u32 {
+        let pid = match i {
+            0 => String::from_str(&env, "rl_pay_0"),
+            1 => String::from_str(&env, "rl_pay_1"),
+            2 => String::from_str(&env, "rl_pay_2"),
+            3 => String::from_str(&env, "rl_pay_3"),
+            _ => String::from_str(&env, "rl_pay_4"),
+        };
+        let amount = 100i128;
+        let merchant = Address::generate(&env);
+        payment_client.grant_role(&admin, &Symbol::new(&env, "MERCHANT"), &merchant);
+        payment_client.create_payment(&create_payment_args(&env, &pid, &merchant, amount));
+        let oracle = Address::generate(&env);
+        payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+        payment_client.verify_payment(
+            &oracle,
+            &pid,
+            &BytesN::from_array(&env, &[(i + 1) as u8; 32]),
+            &customer,
+            &amount,
+        );
+        let token_address = env.as_contract(&refund_client.address, || {
+            env.storage()
+                .persistent()
+                .get::<DataKey, Address>(&DataKey::UsdcToken)
+                .unwrap()
+        });
+        token::StellarAssetClient::new(&env, &token_address).mint(&merchant, &100_000);
+        refund_client.register_payment(&pid, &merchant, &amount, &Symbol::new(&env, "USDC"));
+        refund_client.create_dispute(
+            &pid,
+            &amount,
+            &String::from_str(&env, "reason"),
+            &String::from_str(&env, VALID_CID_V0),
+            &customer,
+            &vec![&env],
+        );
+    }
+
+    let pid6 = String::from_str(&env, "rl_pay_5");
+    let amount = 100i128;
+    let merchant = Address::generate(&env);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "MERCHANT"), &merchant);
+    payment_client.create_payment(&create_payment_args(&env, &pid6, &merchant, amount));
+    let oracle = Address::generate(&env);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.verify_payment(
+        &oracle,
+        &pid6,
+        &BytesN::from_array(&env, &[9u8; 32]),
+        &customer,
+        &amount,
+    );
+    let token_address = env.as_contract(&refund_client.address, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::UsdcToken)
+            .unwrap()
+    });
+    token::StellarAssetClient::new(&env, &token_address).mint(&merchant, &100_000);
+    refund_client.register_payment(&pid6, &merchant, &amount, &Symbol::new(&env, "USDC"));
+
+    let result = refund_client.try_create_dispute(
+        &pid6,
+        &amount,
+        &String::from_str(&env, "reason"),
+        &String::from_str(&env, VALID_CID_V0),
+        &customer,
+        &vec![&env],
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_dispute_global_hourly_rate_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _m, customer, payment_client, refund_client, _) =
+        setup_confirmed_payment_for_dispute(&env, "g_base", 100i128);
+    refund_client.set_dispute_rate_limits(&admin, &50u32, &2u32);
+
+    for i in 0..2u32 {
+        let pid = if i == 0 {
+            String::from_str(&env, "g_pay_0")
+        } else {
+            String::from_str(&env, "g_pay_1")
+        };
+        let amount = 100i128;
+        let merchant = Address::generate(&env);
+        payment_client.grant_role(&admin, &Symbol::new(&env, "MERCHANT"), &merchant);
+        payment_client.create_payment(&create_payment_args(&env, &pid, &merchant, amount));
+        let oracle = Address::generate(&env);
+        payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+        payment_client.verify_payment(
+            &oracle,
+            &pid,
+            &BytesN::from_array(&env, &[(i + 1) as u8; 32]),
+            &customer,
+            &amount,
+        );
+        let token_address = env.as_contract(&refund_client.address, || {
+            env.storage()
+                .persistent()
+                .get::<DataKey, Address>(&DataKey::UsdcToken)
+                .unwrap()
+        });
+        token::StellarAssetClient::new(&env, &token_address).mint(&merchant, &100_000);
+        refund_client.register_payment(&pid, &merchant, &amount, &Symbol::new(&env, "USDC"));
+        refund_client.create_dispute(
+            &pid,
+            &amount,
+            &String::from_str(&env, "reason"),
+            &String::from_str(&env, VALID_CID_V1),
+            &customer,
+            &vec![&env],
+        );
+    }
+
+    let pid3 = String::from_str(&env, "g_pay_2");
+    let amount = 100i128;
+    let merchant = Address::generate(&env);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "MERCHANT"), &merchant);
+    payment_client.create_payment(&create_payment_args(&env, &pid3, &merchant, amount));
+    let oracle = Address::generate(&env);
+    payment_client.grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+    payment_client.verify_payment(
+        &oracle,
+        &pid3,
+        &BytesN::from_array(&env, &[3u8; 32]),
+        &customer,
+        &amount,
+    );
+    let token_address = env.as_contract(&refund_client.address, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::UsdcToken)
+            .unwrap()
+    });
+    token::StellarAssetClient::new(&env, &token_address).mint(&merchant, &100_000);
+    refund_client.register_payment(&pid3, &merchant, &amount, &Symbol::new(&env, "USDC"));
+
+    let result = refund_client.try_create_dispute(
+        &pid3,
+        &amount,
+        &String::from_str(&env, "reason"),
+        &String::from_str(&env, VALID_CID_V1),
+        &customer,
+        &vec![&env],
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_dispute_evidence_valid_cid_v0() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _, customer, _, refund_client, payment_id) =
+        setup_confirmed_payment_for_dispute(&env, "ev_v0", 1000i128);
+    refund_client.set_require_evidence_cid(&admin, &true);
+
+    let dispute_id = refund_client.create_dispute(
+        &payment_id,
+        &500i128,
+        &String::from_str(&env, "reason"),
+        &String::from_str(&env, VALID_CID_V0),
+        &customer,
+        &vec![&env],
+    );
+    assert!(!dispute_id.is_empty());
+}
+
+#[test]
+fn test_create_dispute_evidence_valid_cid_v1() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _, customer, _, refund_client, payment_id) =
+        setup_confirmed_payment_for_dispute(&env, "ev_v1", 1000i128);
+    refund_client.set_require_evidence_cid(&admin, &true);
+
+    let dispute_id = refund_client.create_dispute(
+        &payment_id,
+        &500i128,
+        &String::from_str(&env, "reason"),
+        &String::from_str(&env, VALID_CID_V1),
+        &customer,
+        &vec![&env],
+    );
+    assert!(!dispute_id.is_empty());
+}
+
+#[test]
+fn test_create_dispute_evidence_invalid_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _, customer, _, refund_client, payment_id) =
+        setup_confirmed_payment_for_dispute(&env, "ev_bad", 1000i128);
+    refund_client.set_require_evidence_cid(&admin, &true);
+
+    let result = refund_client.try_create_dispute(
+        &payment_id,
+        &500i128,
+        &String::from_str(&env, "reason"),
+        &String::from_str(&env, "not-a-cid"),
+        &customer,
+        &vec![&env],
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_dispute_evidence_empty_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _, customer, _, refund_client, payment_id) =
+        setup_confirmed_payment_for_dispute(&env, "ev_empty", 1000i128);
+    refund_client.set_require_evidence_cid(&admin, &true);
+
+    let dispute_id = refund_client.create_dispute(
+        &payment_id,
+        &500i128,
+        &String::from_str(&env, "reason"),
+        &String::from_str(&env, ""),
+        &customer,
+        &vec![&env],
+    );
+    assert!(!dispute_id.is_empty());
 }

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -270,8 +270,10 @@ pub enum Error {
     FeeProposalNotReady = 39,
     /// No active fee proposal found.
     NoFeeProposal = 44,
-    /// Issue #180: Evidence field is not a valid IPFS multihash.
-    InvalidEvidence = 40,
+    /// Issue #180: Evidence field is not a valid IPFS multihash (CIDv0/CIDv1).
+    InvalidEvidenceFormat = 40,
+    /// Dispute creation rate limit exceeded (per-payer open cap or global hourly cap).
+    DisputeRateLimitExceeded = 54,
     /// Issue #185: One or both collaborative settlement signatures are invalid.
     InvalidSettlementSignature = 41,
     /// Issue #303: FX oracle rate is stale or unavailable.
@@ -606,6 +608,46 @@ impl<'a> Drop for ReentrancyGuard<'a> {
     }
 }
 
+/// Per-refund reentrancy lock cleared on drop (checks-effects-interactions).
+struct RefundLockGuard<'a> {
+    env: &'a Env,
+    refund_id: String,
+}
+
+impl<'a> Drop for RefundLockGuard<'a> {
+    fn drop(&mut self) {
+        self.env
+            .storage()
+            .persistent()
+            .remove(&DataKey::RefundLock(self.refund_id.clone()));
+    }
+}
+
+/// Admin-configurable dispute creation rate limits.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeRateLimitConfig {
+    /// Max open (Open + UnderReview) disputes per disputer address.
+    pub per_payer_open: u32,
+    /// Max dispute creations per rolling hour across all disputers.
+    pub global_per_hour: u32,
+}
+
+/// Fixed-window counter for global dispute creation rate limiting.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeCreationRateState {
+    pub window_started_at: u64,
+    pub count: u32,
+}
+
+/// Default: max 5 open disputes per payer.
+pub const DEFAULT_DISPUTE_PER_PAYER_OPEN: u32 = 5;
+/// Default: max 100 dispute creations per hour globally.
+pub const DEFAULT_DISPUTE_GLOBAL_PER_HOUR: u32 = 100;
+/// Global dispute creation window length (1 hour).
+pub const DISPUTE_GLOBAL_WINDOW_SECS: u64 = 3600;
+
 #[contracttype]
 pub enum DataKey {
     Payment(String),
@@ -674,6 +716,16 @@ pub enum DataKey {
     SubscriptionTickCounter,
     /// Issue #313: Reentrancy lock for process_refund_internal and settle_payment.
     ReentrancyLock,
+    /// Per-refund reentrancy flag set for the duration of `process_refund_internal`.
+    RefundLock(String),
+    /// Admin-configurable dispute rate limits (`DisputeRateLimitConfig`).
+    DisputeRateLimits,
+    /// Number of open/under-review disputes for a disputer address.
+    PayerOpenDisputeCount(Address),
+    /// Fixed-window global dispute creation counter (`DisputeCreationRateState`).
+    GlobalDisputeCreationRate,
+    /// When true, non-empty dispute evidence must be a valid IPFS CID.
+    RequireEvidenceCid,
     /// Contract version string, updated on each successful upgrade.
     ContractVersion,
     /// Configurable settlement fee rate in basis points (issue: settle_payment fee).
@@ -1322,10 +1374,25 @@ impl RefundManager {
         {
             return Err(Error::Reentrancy);
         }
+        // Per-refund lock: reject concurrent/reentrant process_refund for the same ID.
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::RefundLock(refund_id.clone()))
+        {
+            return Err(Error::Reentrancy);
+        }
         env.storage()
             .persistent()
             .set(&DataKey::ReentrancyLock, &true);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RefundLock(refund_id.clone()), &true);
         let _guard = ReentrancyGuard { env };
+        let _refund_lock = RefundLockGuard {
+            env,
+            refund_id: refund_id.clone(),
+        };
 
         let mut refund = Self::get_refund_internal(env, &refund_id)?;
 
@@ -1428,6 +1495,7 @@ impl RefundManager {
         let from = env.current_contract_address();
         let to: MuxedAddress = (&refund.requester).into();
 
+        // Effects before interactions: mark Completed before any token transfer.
         refund.status = RefundStatus::Completed;
         refund.processed_at = Some(env.ledger().timestamp());
 
@@ -1734,10 +1802,19 @@ impl RefundManager {
             return Err(Error::InvalidAmount);
         }
 
-        // Issue #180: Validate that evidence is a valid IPFS multihash (CIDv0 or CIDv1)
-        if !validate_ipfs_multihash(&evidence) {
-            return Err(Error::InvalidEvidence);
+        // IPFS CID validation when require_evidence_cid is enabled (default: true).
+        // Empty evidence is always allowed; non-empty must be CIDv0/CIDv1 when flag is on.
+        let require_cid = env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::RequireEvidenceCid)
+            .unwrap_or(true);
+        if require_cid && evidence.len() > 0 && !validate_ipfs_multihash(&evidence) {
+            return Err(Error::InvalidEvidenceFormat);
         }
+
+        // Rate limits: max open disputes per payer + global hourly creation cap.
+        Self::enforce_dispute_rate_limits(&env, &disputer)?;
 
         // Issue #77: Load payment and cap dispute amount to confirmed payment amount
         let payment: PaymentCharge = env
@@ -1827,7 +1904,7 @@ impl RefundManager {
             reason,
             evidence,
             status: DisputeStatus::Open,
-            disputer,
+            disputer: disputer.clone(),
             created_at: env.ledger().timestamp(),
             resolved_at: None,
             resolution_notes: None,
@@ -1847,6 +1924,9 @@ impl RefundManager {
             &DataKey::PaymentDisputes(payment_id.clone()),
             &payment_disputes,
         );
+
+        // Record rate-limit counters after successful dispute creation.
+        Self::record_dispute_creation(&env, &disputer);
         Self::bump_ttl(
             &env,
             &DataKey::PaymentDisputes(payment_id.clone()),
@@ -1965,6 +2045,130 @@ impl RefundManager {
         );
 
         Ok(())
+    }
+
+    /// Configure dispute creation rate limits (admin only).
+    ///
+    /// * `per_payer` — max concurrent open/under-review disputes per disputer
+    /// * `global_per_hour` — max dispute creations per hour across all disputers
+    pub fn set_dispute_rate_limits(
+        env: Env,
+        admin: Address,
+        per_payer: u32,
+        global_per_hour: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        let config = DisputeRateLimitConfig {
+            per_payer_open: per_payer,
+            global_per_hour,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::DisputeRateLimits, &config);
+        Ok(())
+    }
+
+    /// Toggle whether non-empty dispute evidence must be a valid IPFS CID.
+    /// Set `false` for testnet/dev to accept arbitrary evidence strings.
+    pub fn set_require_evidence_cid(
+        env: Env,
+        admin: Address,
+        require_cid: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::RequireEvidenceCid, &require_cid);
+        Ok(())
+    }
+
+    fn get_dispute_rate_limits(env: &Env) -> DisputeRateLimitConfig {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DisputeRateLimits)
+            .unwrap_or(DisputeRateLimitConfig {
+                per_payer_open: DEFAULT_DISPUTE_PER_PAYER_OPEN,
+                global_per_hour: DEFAULT_DISPUTE_GLOBAL_PER_HOUR,
+            })
+    }
+
+    fn enforce_dispute_rate_limits(env: &Env, disputer: &Address) -> Result<(), Error> {
+        let limits = Self::get_dispute_rate_limits(env);
+
+        let open: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PayerOpenDisputeCount(disputer.clone()))
+            .unwrap_or(0);
+        if open >= limits.per_payer_open {
+            return Err(Error::DisputeRateLimitExceeded);
+        }
+
+        let now = env.ledger().timestamp();
+        let mut state: DisputeCreationRateState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::GlobalDisputeCreationRate)
+            .unwrap_or(DisputeCreationRateState {
+                window_started_at: now,
+                count: 0,
+            });
+
+        if now.saturating_sub(state.window_started_at) >= DISPUTE_GLOBAL_WINDOW_SECS {
+            state.window_started_at = now;
+            state.count = 0;
+        }
+
+        if state.count >= limits.global_per_hour {
+            return Err(Error::DisputeRateLimitExceeded);
+        }
+
+        Ok(())
+    }
+
+    fn record_dispute_creation(env: &Env, disputer: &Address) {
+        let open_key = DataKey::PayerOpenDisputeCount(disputer.clone());
+        let open: u32 = env.storage().persistent().get(&open_key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&open_key, &open.saturating_add(1));
+        Self::bump_ttl(env, &open_key, SHORT_LIVE_TTL);
+
+        let now = env.ledger().timestamp();
+        let mut state: DisputeCreationRateState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::GlobalDisputeCreationRate)
+            .unwrap_or(DisputeCreationRateState {
+                window_started_at: now,
+                count: 0,
+            });
+
+        if now.saturating_sub(state.window_started_at) >= DISPUTE_GLOBAL_WINDOW_SECS {
+            state.window_started_at = now;
+            state.count = 0;
+        }
+        state.count = state.count.saturating_add(1);
+        env.storage()
+            .persistent()
+            .set(&DataKey::GlobalDisputeCreationRate, &state);
+        Self::bump_ttl(env, &DataKey::GlobalDisputeCreationRate, SHORT_LIVE_TTL);
+    }
+
+    fn release_open_dispute_slot(env: &Env, disputer: &Address) {
+        let open_key = DataKey::PayerOpenDisputeCount(disputer.clone());
+        let open: u32 = env.storage().persistent().get(&open_key).unwrap_or(0);
+        if open > 0 {
+            env.storage()
+                .persistent()
+                .set(&open_key, &(open - 1));
+        }
     }
 
     /// Operator-only: set or update the review deadline for an open or under-review dispute.
@@ -2119,30 +2323,8 @@ impl RefundManager {
             None,
         )?;
 
-        // Process the refund immediately
+        // Process the refund immediately (CEI: status=Completed before token transfer)
         Self::process_refund_internal(&env, &operator, refund_id.clone())?;
-
-        let usdc_token_address = env
-            .storage()
-            .persistent()
-            .get::<DataKey, Address>(&DataKey::UsdcToken)
-            .ok_or(Error::Unauthorized)?;
-        let token_client = token::TokenClient::new(&env, &usdc_token_address);
-        let contract_address = env.current_contract_address();
-        let collector = AccessControl::get_admin(&env).unwrap_or_else(|| contract_address.clone());
-
-        if token_client
-            .try_transfer(&contract_address, &dispute.disputer, &DISPUTE_BOND_AMOUNT)
-            .is_err()
-        {
-            return Err(Error::Unauthorized);
-        }
-        if token_client
-            .try_transfer(&contract_address, &collector, &DISPUTE_BOND_AMOUNT)
-            .is_err()
-        {
-            return Err(Error::Unauthorized);
-        }
 
         let now = env.ledger().timestamp();
 
@@ -2177,7 +2359,7 @@ impl RefundManager {
             ),
         );
 
-        // Update dispute status
+        // Effects before bond interactions: mark dispute resolved first.
         dispute.status = DisputeStatus::Resolved;
         dispute.refund_id = Some(refund_id.clone());
         dispute.resolved_at = Some(now);
@@ -2187,6 +2369,30 @@ impl RefundManager {
             .persistent()
             .set(&DataKey::Dispute(dispute_id.clone()), &dispute);
         Self::bump_dispute_ttl(&env, &dispute_id, &dispute.status);
+        Self::release_open_dispute_slot(&env, &dispute.disputer);
+
+        // Interactions: return bonds after effects are persisted.
+        let usdc_token_address = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::UsdcToken)
+            .ok_or(Error::Unauthorized)?;
+        let token_client = token::TokenClient::new(&env, &usdc_token_address);
+        let contract_address = env.current_contract_address();
+        let collector = AccessControl::get_admin(&env).unwrap_or_else(|| contract_address.clone());
+
+        if token_client
+            .try_transfer(&contract_address, &dispute.disputer, &DISPUTE_BOND_AMOUNT)
+            .is_err()
+        {
+            return Err(Error::Unauthorized);
+        }
+        if token_client
+            .try_transfer(&contract_address, &collector, &DISPUTE_BOND_AMOUNT)
+            .is_err()
+        {
+            return Err(Error::Unauthorized);
+        }
 
         // Emit DISPUTE_RESOLVED event
         env.events().publish(
@@ -2222,28 +2428,6 @@ impl RefundManager {
 
         let now = env.ledger().timestamp();
 
-        let usdc_token_address = env
-            .storage()
-            .persistent()
-            .get::<DataKey, Address>(&DataKey::UsdcToken)
-            .ok_or(Error::Unauthorized)?;
-        let token_client = token::TokenClient::new(&env, &usdc_token_address);
-        let contract_address = env.current_contract_address();
-        let collector = AccessControl::get_admin(&env).unwrap_or_else(|| contract_address.clone());
-
-        if token_client
-            .try_transfer(&contract_address, &dispute.merchant_id, &DISPUTE_BOND_AMOUNT)
-            .is_err()
-        {
-            return Err(Error::Unauthorized);
-        }
-        if token_client
-            .try_transfer(&contract_address, &collector, &DISPUTE_BOND_AMOUNT)
-            .is_err()
-        {
-            return Err(Error::Unauthorized);
-        }
-
         // Persist operator note on-chain for full transparency.
         let note = DisputeOperatorNote {
             dispute_id: dispute_id.clone(),
@@ -2275,6 +2459,7 @@ impl RefundManager {
             ),
         );
 
+        // Effects before bond interactions.
         dispute.status = DisputeStatus::Rejected;
         dispute.resolved_at = Some(now);
         dispute.resolution_notes = Some(resolution_notes);
@@ -2283,6 +2468,29 @@ impl RefundManager {
             .persistent()
             .set(&DataKey::Dispute(dispute_id.clone()), &dispute);
         Self::bump_dispute_ttl(&env, &dispute_id, &dispute.status);
+        Self::release_open_dispute_slot(&env, &dispute.disputer);
+
+        let usdc_token_address = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::UsdcToken)
+            .ok_or(Error::Unauthorized)?;
+        let token_client = token::TokenClient::new(&env, &usdc_token_address);
+        let contract_address = env.current_contract_address();
+        let collector = AccessControl::get_admin(&env).unwrap_or_else(|| contract_address.clone());
+
+        if token_client
+            .try_transfer(&contract_address, &dispute.merchant_id, &DISPUTE_BOND_AMOUNT)
+            .is_err()
+        {
+            return Err(Error::Unauthorized);
+        }
+        if token_client
+            .try_transfer(&contract_address, &collector, &DISPUTE_BOND_AMOUNT)
+            .is_err()
+        {
+            return Err(Error::Unauthorized);
+        }
 
         // Emit DISPUTE_REJECTED event
         env.events().publish(
@@ -2405,6 +2613,7 @@ impl RefundManager {
             .persistent()
             .set(&DataKey::Dispute(dispute_id.clone()), &dispute);
         Self::bump_dispute_ttl(&env, &dispute_id, &dispute.status);
+        Self::release_open_dispute_slot(&env, &dispute.disputer);
 
         // Emit event
         env.events().publish(
@@ -2720,6 +2929,7 @@ impl RefundManager {
                 .persistent()
                 .set(&DataKey::Dispute(dispute_id.clone()), &d);
             Self::bump_dispute_ttl(&env, &dispute_id, &d.status);
+            Self::release_open_dispute_slot(&env, &d.disputer);
         } else {
             let mut d = Self::get_dispute_internal(&env, &dispute_id)?;
             d.status = DisputeStatus::Rejected;
@@ -2728,6 +2938,7 @@ impl RefundManager {
                 .persistent()
                 .set(&DataKey::Dispute(dispute_id.clone()), &d);
             Self::bump_dispute_ttl(&env, &dispute_id, &d.status);
+            Self::release_open_dispute_slot(&env, &d.disputer);
         }
 
         env.events().publish(

--- a/fluxapay/src/merchant_registry.rs
+++ b/fluxapay/src/merchant_registry.rs
@@ -1442,6 +1442,29 @@ impl MerchantRegistry {
         env: Env,
         merchant_id: Address,
         anchor_config: Option<AnchorConfig>,
+    ) -> Result<(), MerchantError> {
+        merchant_id.require_auth();
+
+        let mut merchant = Self::get_merchant_internal(&env, &merchant_id)?;
+        merchant.anchor_config = MaybeAnchorConfig::from(anchor_config.clone());
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::Merchant(merchant_id.clone()), &merchant);
+
+        let domain = match &anchor_config {
+            Some(cfg) => cfg.anchor_domain.clone(),
+            None => String::from_str(&env, ""),
+        };
+        env.events().publish(
+            (
+                Symbol::new(&env, "MERCHANT"),
+                Symbol::new(&env, "ANCHOR_UPDATED"),
+            ),
+            (merchant_id, domain),
+        );
+        Ok(())
+    }
+
     /// Enable/disable whitelist mode for a merchant (issue #516).
     /// Only Business-tier merchants may enable whitelist mode.
     pub fn set_merchant_whitelist_mode(
@@ -1452,8 +1475,6 @@ impl MerchantRegistry {
         merchant_id.require_auth();
 
         let mut merchant = Self::get_merchant_internal(&env, &merchant_id)?;
-        merchant.anchor_config = MaybeAnchorConfig::from(anchor_config.clone());
-
 
         if enabled && merchant.kyc_tier != KycTier::Business {
             return Err(MerchantError::WhitelistModeRequiresBusinessTier);
@@ -1513,6 +1534,10 @@ impl MerchantRegistry {
         env.events().publish(
             (Symbol::new(&env, "MERCHANT"), Symbol::new(&env, "FEE_WAIVER_SET")),
             (merchant_id, expires_at_for_event),
+        );
+        Ok(())
+    }
+
     /// Add a customer address to the merchant's payment whitelist (issue #516).
     pub fn add_to_customer_whitelist(
         env: Env,

--- a/fluxapay/src/proptests.rs
+++ b/fluxapay/src/proptests.rs
@@ -221,4 +221,53 @@ proptest! {
             assert!(!validate_id(&id), "expected invalid (bad char): {}", with_bad);
         }
     }
+
+    /// Accrued amount never decreases between two consecutive timestamps.
+    #[test]
+    fn proptest_stream_accrual_monotonic(
+        checkpoint in 0i128..1_000_000_000i128,
+        last_at in 0u64..1_000_000u64,
+        delta1 in 0u64..10_000u64,
+        delta2 in 0u64..10_000u64,
+        rate in 0i128..1_000_000i128,
+        deposit in 1i128..i128::MAX / 4,
+    ) {
+        use crate::stream::compute_total_accrued;
+
+        let t1 = last_at.saturating_add(delta1);
+        let t2 = t1.saturating_add(delta2);
+        let a1 = compute_total_accrued(checkpoint, last_at, t1, rate, deposit);
+        let a2 = compute_total_accrued(checkpoint, last_at, t2, rate, deposit);
+        prop_assert!(a2 >= a1, "accrual decreased: {} -> {} (t {} -> {})", a1, a2, t1, t2);
+    }
+
+    /// Large rates/durations must not overflow or panic (saturating arithmetic).
+    #[test]
+    fn proptest_stream_accrual_no_overflow(
+        checkpoint in 0i128..=i128::MAX / 2,
+        last_at in 0u64..u64::MAX / 2,
+        now_offset in 0u64..u64::MAX / 2,
+        rate in 0i128..=i128::MAX,
+        deposit in 0i128..=i128::MAX,
+    ) {
+        use crate::stream::compute_total_accrued;
+
+        let now = last_at.saturating_add(now_offset);
+        let accrued = compute_total_accrued(checkpoint, last_at, now, rate, deposit);
+        prop_assert!(accrued >= 0);
+        prop_assert!(accrued <= deposit.max(0));
+    }
+
+    /// Withdrawal never drives remaining deposit negative.
+    #[test]
+    fn proptest_stream_remaining_deposit_non_negative(
+        remaining in 0i128..=i128::MAX,
+        withdraw in 0i128..=i128::MAX,
+    ) {
+        use crate::stream::compute_remaining_after_withdraw;
+
+        let after = compute_remaining_after_withdraw(remaining, withdraw);
+        prop_assert!(after >= 0);
+        prop_assert!(after <= remaining.max(0));
+    }
 }

--- a/fluxapay/src/stream.rs
+++ b/fluxapay/src/stream.rs
@@ -6,6 +6,33 @@ use crate::PaymentProcessor;
 
 // ─── Data types ───────────────────────────────────────────────────────────────
 
+/// Pure accrual computation (lazy formula with saturating arithmetic).
+///
+/// `total = min(deposit, checkpoint + (now - last_checkpoint) * rate)`
+pub fn compute_total_accrued(
+    accrued_at_checkpoint: i128,
+    last_checkpoint_at: u64,
+    now: u64,
+    rate_per_second: i128,
+    remaining_deposit: i128,
+) -> i128 {
+    let rate = rate_per_second.max(0);
+    let deposit = remaining_deposit.max(0);
+    let elapsed = now.saturating_sub(last_checkpoint_at);
+    let newly_accrued = (elapsed as i128).saturating_mul(rate);
+    accrued_at_checkpoint
+        .saturating_add(newly_accrued)
+        .min(deposit)
+        .max(0)
+}
+
+/// Remaining deposit after a withdrawal; never negative.
+pub fn compute_remaining_after_withdraw(remaining_deposit: i128, withdraw_amount: i128) -> i128 {
+    remaining_deposit
+        .saturating_sub(withdraw_amount.max(0))
+        .max(0)
+}
+
 /// Status of a payment stream.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -525,14 +552,13 @@ impl PaymentStreaming {
         }
 
         let now = env.ledger().timestamp();
-        let elapsed = now.saturating_sub(stream.last_checkpoint_at);
-        let newly_accrued = (elapsed as i128).saturating_mul(stream.rate_per_second);
-        let total = stream
-            .accrued_at_checkpoint
-            .saturating_add(newly_accrued)
-            .min(stream.remaining_deposit);
-
-        Ok(total)
+        Ok(compute_total_accrued(
+            stream.accrued_at_checkpoint,
+            stream.last_checkpoint_at,
+            now,
+            stream.rate_per_second,
+            stream.remaining_deposit,
+        ))
     }
 
     /// Query streams created by the given sender.

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -3073,6 +3073,41 @@ fn test_process_refund_reentrancy_lock_cleared() {
 }
 
 #[test]
+fn test_process_refund_same_id_only_once() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_refund_manager(&env);
+
+    let payment_id = String::from_str(&env, "payment_concurrent_refund");
+    let merchant_id = Address::generate(&env);
+    let requester = Address::generate(&env);
+
+    client.register_payment(
+        &payment_id,
+        &merchant_id,
+        &5000i128,
+        &Symbol::new(&env, "USDC"),
+    );
+
+    let refund_id = client.create_refund(
+        &payment_id,
+        &1000i128,
+        &String::from_str(&env, "once"),
+        &requester,
+    );
+
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_settlement_operator(&env), &operator);
+
+    client.process_refund(&operator, &refund_id);
+    let second = client.try_process_refund(&operator, &refund_id);
+    assert!(second.is_err());
+
+    let refund = client.get_refund(&refund_id);
+    assert_eq!(refund.status, RefundStatus::Completed);
+}
+
+#[test]
 fn test_settle_payment_reentrancy_guard_normal_flow() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
PR description
Summary
Hardens dispute spam resistance, refund reentrancy ordering, IPFS evidence validation, and stream accrual invariants. All work is on branch sec-fixes.

Task 1 — Dispute rate limiting
Per-payer cap: max 5 open (Open/UnderReview) disputes per disputer (default)
Global cap: max 100 creations per hour across all disputers (default)
New error: Error::DisputeRateLimitExceeded (54)
Admin: set_dispute_rate_limits(admin, per_payer, global_per_hour)
Storage: DisputeRateLimits, PayerOpenDisputeCount, GlobalDisputeCreationRate
Open slots released on resolve/reject (and related resolution paths)
Tests: 6th open dispute rejected; global hourly limit enforced

Task 2 — Refund reentrancy / CEI
Confirmed process_refund_internal sets status = Completed before token::transfer
Added DataKey::RefundLock(refund_id) + RefundLockGuard (cleared on drop)
Kept contract-wide ReentrancyLock
resolve_dispute_with_refund / reject_dispute: persist dispute status before bond transfers
Test: second process_refund for the same ID fails after first succeeds
Documented in SECURITY.md (Refund Reentrancy Protection)

Task 3 — Stream accrual proptests
Pure helpers: compute_total_accrued, compute_remaining_after_withdraw (saturating math)
get_accrued_amount uses the shared helper
Properties:
proptest_stream_accrual_monotonic
proptest_stream_accrual_no_overflow
proptest_stream_remaining_deposit_non_negative
Run with: PROPTEST_CASES=256 cargo test -p fluxapay proptest_stream_accrual --all-features

Task 4 — Dispute evidence IPFS validation
Non-empty evidence validated via validate_ipfs_multihash when require_evidence_cid is true (default)
Empty evidence allowed; invalid CID → Error::InvalidEvidenceFormat (40)
Admin: set_require_evidence_cid(admin, require_cid) for testnet/dev
Docs updated in docs/local-invoke.md
Tests: valid CIDv0, CIDv1, invalid string, empty string
Test plan

 PROPTEST_CASES=256 cargo test -p fluxapay proptest_stream_accrual --all-features -- --test-threads=1

 cargo test -p fluxapay --all-features dispute_rate_limit -- --test-threads=1

 cargo test -p fluxapay --all-features create_dispute_evidence -- --test-threads=1

 cargo test -p fluxapay --all-features process_refund_same_id -- --test-threads=1

 Confirm admin can tune limits / disable CID enforcement on testnet
Note: Full cargo test --all-features still fails on pre-existing compile errors elsewhere in the crate (not introduced by these tasks). A minimal brace/signature repair in merchant_registry.rs was needed only so the file parses; unrelated broken APIs remain untouched.

closes #466 
closes #468 
closes #469 
closes #470