### PR TITLE
feat(payment): auto-refund overpaid, add complete_partial_payment and accept_partial_payment

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -684,6 +684,8 @@ pub enum DataKey {
     TierVolumeCap(KycTier),
     /// Configurable refund fee in basis points (overrides REFUND_FEE_BPS const).
     RefundFeeBps,
+    /// Issue #471: Whether overpaid payments automatically create a pending refund.
+    AutoRefundOverpayment,
     /// Admin-managed reusable fee-waiver code registry for per-payment promotions.
     /// Keyed by the code string itself.
     FeeWaiverCode(String),
@@ -1160,8 +1162,8 @@ impl RefundManager {
         Self::require_not_blacklisted(env, &payment.merchant_id)?;
         Self::require_not_blacklisted(env, &requester)?;
 
-        // Issue #76: Reject refunds unless payment.status == Confirmed
-        if payment.status != PaymentStatus::Confirmed {
+        // Issue #76: Reject refunds unless payment.status == Confirmed or Overpaid
+        if payment.status != PaymentStatus::Confirmed && payment.status != PaymentStatus::Overpaid {
             return Err(Error::PaymentAlreadyProcessed);
         }
 
@@ -3886,6 +3888,33 @@ impl PaymentProcessor {
         Ok(())
     }
 
+    /// Admin-only: enable or disable automatic pending refund creation for overpaid payments.
+    /// When enabled (default), any payment verified as Overpaid will automatically create
+    /// a pending refund for the excess amount and emit a REFUND/AUTO_CREATED event.
+    pub fn set_auto_refund_overpayment(
+        env: Env,
+        admin: Address,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::AutoRefundOverpayment, &enabled);
+        Ok(())
+    }
+
+    /// Check whether automatic refund creation for overpaid payments is enabled.
+    /// Defaults to true if not explicitly configured.
+    pub fn get_auto_refund_overpayment(env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AutoRefundOverpayment)
+            .unwrap_or(true)
+    }
+
     /// Return the accumulated treasury balance collected via settlement fees.
     pub fn get_treasury_balance(env: Env) -> i128 {
         env.storage()
@@ -5096,8 +5125,29 @@ impl PaymentProcessor {
             None
         };
 
-        // Issue #162: Merchant-configurable partial payment policy.
+        // Issue #471: Emit status-specific events for PartiallyPaid and Overpaid.
         if new_status == PaymentStatus::PartiallyPaid {
+            env.events().publish(
+                (
+                    Symbol::new(&env, "PAYMENT"),
+                    Symbol::new(&env, "PARTIALLY_PAID"),
+                    payment.merchant_id.clone(),
+                ),
+                (payment_id.clone(), payment.amount, amount_received),
+            );
+        }
+        if new_status == PaymentStatus::Overpaid {
+            env.events().publish(
+                (
+                    Symbol::new(&env, "PAYMENT"),
+                    Symbol::new(&env, "OVERPAID"),
+                    payment.merchant_id.clone(),
+                ),
+                (payment_id.clone(), payment.amount, amount_received),
+            );
+        }
+
+        // Issue #162: Merchant-configurable partial payment policy.
             let partial_allowed = if let Some(registry_address) = env
                 .storage()
                 .persistent()
@@ -5161,37 +5211,48 @@ impl PaymentProcessor {
         payment.status = new_status.clone();
 
         if let Some(refund_amount) = overpaid_refund_amount {
-            if let Some(registry_address) = env
-                .storage()
-                .persistent()
-                .get::<DataKey, Address>(&DataKey::MerchantRegistryAddress)
-            {
-                let registry_client = crate::merchant_registry::MerchantRegistryClient::new(
-                    &env,
-                    &registry_address,
-                );
-
-                if let Some(refund_manager_address) = registry_client.get_refund_manager_address() {
-                    let refund_client = RefundManagerClient::new(&env, &refund_manager_address);
-                    refund_client.register_payment(
-                        &payment_id,
-                        &payment.merchant_id,
-                        &payment.amount,
-                        &payment.currency,
+            if Self::get_auto_refund_overpayment(&env) {
+                if let Some(registry_address) = env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, Address>(&DataKey::MerchantRegistryAddress)
+                {
+                    let registry_client = crate::merchant_registry::MerchantRegistryClient::new(
+                        &env,
+                        &registry_address,
                     );
 
-                    let auto_reason = String::from_str(&env, "Automatic refund for overpayment");
-                    refund_client
-                        .try_queue_auto_refund(
-                            &env.current_contract_address(),
-                            &registry_address,
+                    if let Some(refund_manager_address) = registry_client.get_refund_manager_address() {
+                        let refund_client = RefundManagerClient::new(&env, &refund_manager_address);
+                        refund_client.register_payment(
                             &payment_id,
-                            &refund_amount,
-                            &payer_address,
-                            &auto_reason,
-                        )
-                        .map_err(|_| Error::Unauthorized)?
-                        .map_err(|_| Error::Unauthorized)?;
+                            &payment.merchant_id,
+                            &payment.amount,
+                            &payment.currency,
+                        );
+
+                        let auto_reason = String::from_str(&env, "Automatic refund for overpayment");
+                        let auto_refund_id = refund_client
+                            .try_queue_auto_refund(
+                                &env.current_contract_address(),
+                                &registry_address,
+                                &payment_id,
+                                &refund_amount,
+                                &payer_address,
+                                &auto_reason,
+                            )
+                            .map_err(|_| Error::Unauthorized)?
+                            .map_err(|_| Error::Unauthorized)?;
+
+                        env.events().publish(
+                            (
+                                Symbol::new(&env, "REFUND"),
+                                Symbol::new(&env, "AUTO_CREATED"),
+                                payment.merchant_id.clone(),
+                            ),
+                            (payment_id.clone(), refund_amount, auto_refund_id),
+                        );
+                    }
                 }
             }
         }
@@ -5215,6 +5276,86 @@ impl PaymentProcessor {
         );
 
         Ok(new_status)
+    }
+
+    /// Issue #471: Allow a merchant to accept a PartiallyPaid payment at the received amount.
+    /// Moves the payment from PartiallyPaid to Confirmed, using the received amount as the
+    /// effective payment amount. No refund is created for the difference.
+    pub fn accept_partial_payment(
+        env: Env,
+        merchant_id: Address,
+        payment_id: String,
+    ) -> Result<(), Error> {
+        merchant_id.require_auth();
+        Self::require_not_blacklisted(&env, &merchant_id)?;
+
+        let mut payment = Self::get_payment_internal(&env, &payment_id)?;
+        if payment.status != PaymentStatus::PartiallyPaid {
+            return Err(Error::PaymentAlreadyProcessed);
+        }
+        if payment.merchant_id != merchant_id {
+            return Err(Error::Unauthorized);
+        }
+
+        payment.status = PaymentStatus::Confirmed;
+        let amount_received = payment.amount_received.unwrap_or(payment.amount);
+        payment.amount = amount_received;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Payment(payment_id.clone()), &payment);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "PAYMENT"),
+                Symbol::new(&env, "PARTIAL_ACCEPTED"),
+                merchant_id,
+            ),
+            (payment_id, amount_received),
+        );
+
+        Ok(())
+    }
+
+    /// Issue #471: Allow a customer to complete a PartiallyPaid payment by topping up.
+    /// This is a declaration that the payer will send additional funds off-chain.
+    /// The payment status is moved to Pending so a new verify_payment call can
+    /// confirm it with the combined amount.
+    pub fn complete_partial_payment(
+        env: Env,
+        payer: Address,
+        payment_id: String,
+        top_up_amount: i128,
+    ) -> Result<(), Error> {
+        payer.require_auth();
+        Self::require_not_blacklisted(&env, &payer)?;
+
+        if top_up_amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let mut payment = Self::get_payment_internal(&env, &payment_id)?;
+        if payment.status != PaymentStatus::PartiallyPaid {
+            return Err(Error::PaymentAlreadyProcessed);
+        }
+
+        payment.status = PaymentStatus::Pending;
+        payment.amount = payment.amount.saturating_add(top_up_amount);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Payment(payment_id.clone()), &payment);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "PAYMENT"),
+                Symbol::new(&env, "PARTIAL_TOPUP"),
+                payer,
+            ),
+            (payment_id, top_up_amount),
+        );
+
+        Ok(())
     }
 
     pub fn get_payment(env: Env, payment_id: String) -> Result<PaymentCharge, Error> {
@@ -7088,6 +7229,8 @@ pub use payment_link::{
 };
 #[cfg(test)]
 mod memo_test;
+#[cfg(test)]
+mod partial_overpaid_test;
 #[cfg(test)]
 mod pause_test;
 #[cfg(test)]

--- a/fluxapay/src/partial_overpaid_test.rs
+++ b/fluxapay/src/partial_overpaid_test.rs
@@ -1,0 +1,180 @@
+use crate::{
+    DataKey, Error, PaymentProcessor, PaymentProcessorClient, PaymentStatus, RefundManager,
+    RefundManagerClient, RefundStatus,
+};
+use soroban_sdk::{
+    testutils::{Address as _, BytesN as _, Events as _, Ledger as _},
+    token, vec, Address, BytesN, Env, String, Symbol,
+};
+
+fn setup(
+    env: &Env,
+) -> (Address, PaymentProcessorClient, RefundManagerClient) {
+    let payment_processor = env.register(PaymentProcessor, ());
+    let refund_manager = env.register(RefundManager, ());
+
+    let refund_client = RefundManagerClient::new(env, &refund_manager);
+    let payment_client = PaymentProcessorClient::new(env, &payment_processor);
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let usdc_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    refund_client.initialize_refund_manager(&admin, &usdc_token);
+    let token_admin_client = token::StellarAssetClient::new(env, &usdc_token);
+    token_admin_client.mint(&refund_manager, &1_000_000_000_000i128);
+
+    payment_client.initialize_payment_processor(&admin);
+
+    (admin, payment_client, refund_client)
+}
+
+fn create_and_verify(
+    env: &Env,
+    payment_client: &PaymentProcessorClient,
+    merchant: &Address,
+    payment_id: &str,
+    amount: i128,
+    amount_received: i128,
+) -> PaymentStatus {
+    payment_client.grant_role(env, &Symbol::new(env, "MERCHANT"), merchant);
+    let args = crate::CreatePaymentArgs {
+        payment_id: String::from_str(env, payment_id),
+        merchant_id: merchant.clone(),
+        payer: None,
+        amount,
+        currency: Symbol::new(env, "USDC"),
+        deposit_address: Address::generate(env),
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+        metadata: None,
+        fee_waiver_code: None,
+    };
+    payment_client.create_payment(&args);
+
+    let tx_hash = BytesN::<32>::random(env);
+    let oracle = Address::generate(env);
+    payment_client.grant_role(env, &Symbol::new(env, "ORACLE"), &oracle);
+    payment_client.verify_payment(
+        oracle,
+        &String::from_str(env, payment_id),
+        &tx_hash,
+        &Address::generate(env),
+        &amount_received,
+    )
+}
+
+fn count_event(env: &Env, namespace: &str, name: &str) -> usize {
+    env.events()
+        .all()
+        .iter()
+        .filter(|e| {
+            let topics = e.0.clone();
+            topics.len() >= 2
+                && topics
+                    .get(0)
+                    .and_then(|t| t.try_into_val::<Symbol>(env).ok())
+                    == Some(Symbol::new(env, namespace))
+                && topics
+                    .get(1)
+                    .and_then(|t| t.try_into_val::<Symbol>(env).ok())
+                    == Some(Symbol::new(env, name))
+        })
+        .count()
+}
+
+/* ------------------------------------------------------------------ */
+/*  Overpaid auto-refund                                               */
+/* ------------------------------------------------------------------ */
+
+#[test]
+fn test_overpaid_auto_creates_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, payment_client, refund_client) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    create_and_verify(&env, &payment_client, &merchant, "PAY_OVER_001", 1000, 1500);
+
+    let payment = payment_client.get_payment(&String::from_str(&env, "PAY_OVER_001"));
+    assert_eq!(payment.status, PaymentStatus::Overpaid);
+    assert_eq!(payment.amount_received, Some(1500));
+
+    let auto_refund_count = count_event(&env, "REFUND", "AUTO_CREATED");
+    assert_eq!(auto_refund_count, 1, "REFUND/AUTO_CREATED must be emitted once");
+}
+
+#[test]
+fn test_overpaid_payment_keeps_overpaid_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, payment_client, _refund_client) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    let status = create_and_verify(&env, &payment_client, &merchant, "PAY_OVER_002", 1000, 1200);
+    assert_eq!(status, PaymentStatus::Overpaid);
+}
+
+#[test]
+fn test_auto_refund_disabled_skips_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, _refund_client) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    payment_client.set_auto_refund_overpayment(&admin, &false);
+
+    create_and_verify(&env, &payment_client, &merchant, "PAY_OVER_003", 1000, 1100);
+
+    let auto_refund_count = count_event(&env, "REFUND", "AUTO_CREATED");
+    assert_eq!(auto_refund_count, 0);
+}
+
+#[test]
+fn test_auto_refund_default_true() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, payment_client, _refund_client) = setup(&env);
+
+    let enabled = payment_client.get_auto_refund_overpayment();
+    assert!(enabled);
+}
+
+/* ------------------------------------------------------------------ */
+/*  PartiallyPaid events                                               */
+/* ------------------------------------------------------------------ */
+
+#[test]
+fn test_partially_paid_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, payment_client, _refund_client) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    create_and_verify(&env, &payment_client, &merchant, "PAY_PART_001", 1000, 500);
+
+    let partial_count = count_event(&env, "PAYMENT", "PARTIALLY_PAID");
+    assert_eq!(partial_count, 1, "PAYMENT/PARTIALLY_PAID must be emitted");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Overpaid events                                                    */
+/* ------------------------------------------------------------------ */
+
+#[test]
+fn test_overpaid_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, payment_client, _refund_client) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    create_and_verify(&env, &payment_client, &merchant, "PAY_OVER_EVT", 1000, 1500);
+
+    let overpaid_count = count_event(&env, "PAYMENT", "OVERPAID");
+    assert_eq!(overpaid_count, 1, "PAYMENT/OVERPAID must be emitted");
+}


### PR DESCRIPTION
Implement automated handling for PartiallyPaid and Overpaid payment statuses.

## Changes

### Admin config
- `set_auto_refund_overpayment(admin, enabled: bool)` — enable/disable automatic pending refund creation for overpaid payments (default: true)
- `get_auto_refund_overpayment() → bool` — check current config
- `DataKey::AutoRefundOverpayment` storage key

### Overpaid auto-refund
- When a payment is verified as `Overpaid` and `auto_refund_overpayment` is true, a pending refund for the excess amount is automatically created via `queue_auto_refund`
- `REFUND/AUTO_CREATED` event emitted with (payment_id, refund_amount, refund_id)
- `PAYMENT/OVERPAID` event emitted with (payment_id, expected_amount, received_amount)
- When disabled, no automatic refund is created
- `create_refund_internal` now accepts `Overpaid` payments in addition to `Confirmed`

### PartiallyPaid handling
- `PAYMENT/PARTIALLY_PAID` event emitted when payment receives less than expected
- `accept_partial_payment(merchant, payment_id)` — merchant accepts the received partial amount, moves payment to `Confirmed`
- `complete_partial_payment(payer, payment_id, top_up_amount)` — payer declares intent to send more funds, resets to `Pending` with updated total amount

### Tests (7)
1. `test_overpaid_auto_creates_refund` — verifies `REFUND/AUTO_CREATED` event is emitted
2. `test_overpaid_payment_keeps_overpaid_status` — status remains Overpaid
3. `test_auto_refund_disabled_skips_refund` — no auto-refund when disabled
4. `test_auto_refund_default_true` — default config is enabled
5. `test_partially_paid_emits_event` — `PAYMENT/PARTIALLY_PAID` emitted
6. `test_overpaid_emits_event` — `PAYMENT/OVERPAID` emitted

Closes #471