### PR TITLE
feat(merchant): add settlement schedule configuration and trigger_settlement

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -18,6 +18,12 @@ const REFUND_FEE_BPS: i128 = 100;
 const REFUND_COOLDOWN_SECS: u64 = 300;
 /// Default refund request expiry period (30 days in seconds).
 const REFUND_EXPIRY_SECS: u64 = 30 * 24 * 60 * 60;
+/// Issue #480: Minimum time between daily settlements (24 hours in seconds).
+const SETTLEMENT_DAILY_INTERVAL_SECS: u64 = 86_400;
+/// Issue #480: Minimum time between weekly settlements (7 days in seconds).
+const SETTLEMENT_WEEKLY_INTERVAL_SECS: u64 = 604_800;
+/// Issue #480: Minimum pending balance required to trigger a settlement.
+const SETTLEMENT_MIN_AMOUNT: i128 = 1_000_000; // 0.1 USDC (7 decimals)
 /// Minimum number of arbitrators required for dispute resolution voting.
 const ARBITRATOR_VOTING_THRESHOLD: u32 = 3;
 /// Fixed dispute bond in the contract's stablecoin denomination.
@@ -6059,6 +6065,24 @@ impl PaymentProcessor {
 
         payment.status = PaymentStatus::Settled;
 
+        // Issue #480: Accumulate net merchant amount to pending settlement.
+        let net_merchant_amount: i128 = splits
+            .iter()
+            .find(|s| s.recipient == payment.merchant_id)
+            .map(|s| s.amount)
+            .unwrap_or(0);
+        if net_merchant_amount > 0 {
+            if let Some(registry_address) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Address>(&DataKey::MerchantRegistryAddress)
+            {
+                let registry_client =
+                    crate::merchant_registry::MerchantRegistryClient::new(&env, &registry_address);
+                registry_client.add_pending_settlement(&payment.merchant_id, &net_merchant_amount);
+            }
+        }
+
         env.storage()
             .persistent()
             .set(&DataKey::Payment(payment_id.clone()), &payment);
@@ -6110,6 +6134,95 @@ impl PaymentProcessor {
         }
 
         Ok(())
+    }
+
+    /// Issue #480: Trigger a settlement for a merchant's accumulated pending balance.
+    ///
+    /// Sweeps the merchant's pending settlement balance to their payout address.
+    /// For `Daily` and `Weekly` schedules, enforces a minimum time since the
+    /// last settlement. For `Manual`, settles immediately as long as the pending
+    /// balance exceeds `SETTLEMENT_MIN_AMOUNT`.
+    pub fn trigger_settlement(
+        env: Env,
+        operator: Address,
+        merchant_id: Address,
+    ) -> Result<i128, Error> {
+        operator.require_auth();
+
+        if !AccessControl::has_role(&env, &role_settlement_operator(&env), &operator) {
+            return Err(Error::Unauthorized);
+        }
+
+        // Get merchant info from registry.
+        let registry_address = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::MerchantRegistryAddress)
+            .ok_or(Error::Unauthorized)?;
+        let registry_client =
+            crate::merchant_registry::MerchantRegistryClient::new(&env, &registry_address);
+
+        let merchant = registry_client.get_merchant(&merchant_id);
+
+        // Resolve the USDC token address.
+        let usdc_token = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::UsdcToken)
+            .ok_or(Error::Unauthorized)?;
+
+        // Determine the payout address.
+        let payout_address = merchant.payout_address.ok_or(Error::InvalidAddress)?;
+
+        // Check minimum time since last settlement for scheduled types.
+        let now = env.ledger().timestamp();
+        let min_interval = match merchant.settlement_schedule {
+            crate::merchant_registry::SettlementSchedule::Daily => {
+                Some(SETTLEMENT_DAILY_INTERVAL_SECS)
+            }
+            crate::merchant_registry::SettlementSchedule::Weekly => {
+                Some(SETTLEMENT_WEEKLY_INTERVAL_SECS)
+            }
+            crate::merchant_registry::SettlementSchedule::Manual => None,
+        };
+
+        if let Some(interval) = min_interval {
+            if let Some(last) = merchant.last_settlement_at {
+                if now < last.saturating_add(interval) {
+                    // Schedule not yet eligible; still allow manual override with operator auth.
+                    return Err(Error::Unauthorized);
+                }
+            }
+        }
+
+        // Read the pending settlement balance.
+        let pending = registry_client.get_pending_settlement(&merchant_id);
+        if pending < SETTLEMENT_MIN_AMOUNT {
+            return Err(Error::InvalidAmount);
+        }
+
+        // Transfer USDC from the PaymentProcessor contract to the merchant's payout address.
+        let token_client = token::TokenClient::new(&env, &usdc_token);
+        let from = env.current_contract_address();
+        token_client.transfer(&from, &payout_address, &pending);
+
+        // Clear pending settlement balance.
+        registry_client.clear_pending_settlement(&merchant_id);
+
+        // Update last_settlement_at on the merchant record.
+        registry_client.set_last_settlement_at(&merchant_id, &now);
+
+        // Emit MERCHANT/SETTLEMENT_TRIGGERED event.
+        env.events().publish(
+            (
+                Symbol::new(&env, "MERCHANT"),
+                Symbol::new(&env, "SETTLEMENT_TRIGGERED"),
+                merchant_id,
+            ),
+            (pending,),
+        );
+
+        Ok(pending)
     }
 
     pub fn prune_expired_payments(
@@ -7261,3 +7374,5 @@ pub use gas_estimator::{CostEstimate, GasEstimator, GasEstimatorClient, Operatio
 mod mock_dex_router;
 #[cfg(test)]
 mod swap_test;
+#[cfg(test)]
+mod settlement_test;

--- a/fluxapay/src/merchant_registry.rs
+++ b/fluxapay/src/merchant_registry.rs
@@ -153,7 +153,16 @@ pub struct Merchant {
     pub fee_config: MaybeFeeConfig,
     /// IPFS hash for content-addressable merchant metadata (issue #208)
     pub metadata_hash: Option<String>,
-    /// Multi-currency payout addresses mapping (issue #216)
+    /// Merchant settlement schedule configuration (issue #480).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SettlementSchedule {
+    Daily,
+    Weekly,
+    Manual,
+}
+
+/// Multi-currency payout addresses mapping (issue #216)
     pub currency_payout_addresses: Map<String, Address>,
     /// Whitelist of approved payout addresses (issue #210)
     pub payout_whitelist: Vec<Address>,
@@ -164,6 +173,10 @@ pub struct Merchant {
     /// Used for onboarding campaigns and merchant promotions.
     /// `None` means no merchant-wide fee waiver is active.
     pub fee_waiver_expires_at: Option<u64>,
+    /// Issue #480: Settlement schedule for accumulated balance sweep.
+    pub settlement_schedule: SettlementSchedule,
+    /// Issue #480: Timestamp of the last triggered settlement.
+    pub last_settlement_at: Option<u64>,
     /// When true, only customers in `MerchantDataKey::MerchantCustomerWhitelist`
     /// may initiate payments to this merchant (issue #516).
     pub whitelist_mode: bool,
@@ -187,6 +200,8 @@ pub enum MerchantDataKey {
     TierLimit(KycTier),
     /// Customer whitelist for a merchant in whitelist mode (issue #516)
     MerchantCustomerWhitelist(Address),
+    /// Issue #480: Accumulated confirmed payment net amounts awaiting settlement.
+    MerchantPendingSettlement(Address),
 }
 
 /// Platform fee configuration stored in MerchantRegistry.
@@ -320,6 +335,8 @@ impl MerchantRegistry {
             payout_whitelist: vec![&env],
             anchor_config: MaybeAnchorConfig::None,
             fee_waiver_expires_at: None,
+            settlement_schedule: SettlementSchedule::Manual,
+            last_settlement_at: None,
             whitelist_mode: false,
         };
 
@@ -1600,5 +1617,91 @@ impl MerchantRegistry {
             .unwrap_or_else(|| vec![&env]);
 
         Ok(whitelist.iter().any(|addr| addr == customer))
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Issue #480: Merchant settlement schedule                            */
+    /* ------------------------------------------------------------------ */
+
+    /// Set the settlement schedule for a merchant.
+    /// Only the merchant can change their own schedule.
+    pub fn set_settlement_schedule(
+        env: Env,
+        merchant_id: Address,
+        schedule: SettlementSchedule,
+    ) -> Result<(), MerchantError> {
+        merchant_id.require_auth();
+        let mut merchant = Self::get_merchant_internal(&env, &merchant_id)?;
+        merchant.settlement_schedule = schedule.clone();
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::Merchant(merchant_id.clone()), &merchant);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "MERCHANT"),
+                Symbol::new(&env, "SETTLEMENT_SCHEDULE_UPDATED"),
+            ),
+            (merchant_id, schedule),
+        );
+
+        Ok(())
+    }
+
+    /// Get the accumulated pending settlement amount for a merchant.
+    pub fn get_pending_settlement(env: Env, merchant_id: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&MerchantDataKey::MerchantPendingSettlement(merchant_id))
+            .unwrap_or(0)
+    }
+
+    /// Add an amount to the merchant's pending settlement balance.
+    /// Called by settle_payment in PaymentProcessor after a payment is settled.
+    pub fn add_pending_settlement(
+        env: &Env,
+        merchant_id: &Address,
+        amount: i128,
+    ) {
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&MerchantDataKey::MerchantPendingSettlement(merchant_id.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(
+                &MerchantDataKey::MerchantPendingSettlement(merchant_id.clone()),
+                &current.saturating_add(amount),
+            );
+    }
+
+    /// Clear the pending settlement balance for a merchant.
+    pub fn clear_pending_settlement(env: &Env, merchant_id: &Address) {
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::MerchantPendingSettlement(merchant_id.clone()), &0i128);
+    }
+
+    /// Get the last settlement timestamp for a merchant.
+    pub fn get_last_settlement_at(env: &Env, merchant_id: &Address) -> Option<u64> {
+        Self::get_merchant_internal(env, merchant_id)
+            .ok()
+            .map(|m| m.last_settlement_at)
+            .unwrap_or(None)
+    }
+
+    /// Set the last settlement timestamp for a merchant.
+    pub fn set_last_settlement_at(
+        env: Env,
+        merchant_id: Address,
+        timestamp: u64,
+    ) -> Result<(), MerchantError> {
+        let mut merchant = Self::get_merchant_internal(&env, &merchant_id)?;
+        merchant.last_settlement_at = Some(timestamp);
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::Merchant(merchant_id), &merchant);
+        Ok(())
     }
 }

--- a/fluxapay/src/settlement_test.rs
+++ b/fluxapay/src/settlement_test.rs
@@ -1,0 +1,273 @@
+use crate::{
+    merchant_registry::{
+        MerchantRegistry, MerchantRegistryClient, SettlementSchedule,
+    },
+    Error, PaymentProcessor, PaymentProcessorClient, PaymentStatus,
+};
+use soroban_sdk::{
+    testutils::{Address as _, BytesN as _, Ledger as _},
+    token, vec, Address, BytesN, Env, String, Symbol,
+};
+
+fn setup(
+    env: &Env,
+) -> (
+    Address,
+    PaymentProcessorClient,
+    MerchantRegistryClient,
+    Address,
+) {
+    let payment_processor = env.register(PaymentProcessor, ());
+    let merchant_registry = env.register(MerchantRegistry, ());
+    let refund_manager = env.register(crate::RefundManager, ());
+
+    let payment_client = PaymentProcessorClient::new(env, &payment_processor);
+    let merchant_client = MerchantRegistryClient::new(env, &merchant_registry);
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let usdc_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    let refund_client = crate::RefundManagerClient::new(env, &refund_manager);
+    refund_client.initialize_refund_manager(&admin, &usdc_token);
+    let token_admin_client = token::StellarAssetClient::new(env, &usdc_token);
+    token_admin_client.mint(&refund_manager, &1_000_000_000_000i128);
+
+    payment_client.initialize_payment_processor(&admin);
+    merchant_client.initialize(&admin);
+
+    // Wire payment processor to merchant registry.
+    payment_client.set_merchant_registry_address(&admin, &merchant_client.address);
+
+    let merchant = Address::generate(env);
+    (
+        admin,
+        payment_client,
+        merchant_client,
+        merchant,
+    )
+}
+
+fn register_merchant(
+    env: &Env,
+    admin: &Address,
+    merchant_client: &MerchantRegistryClient,
+    merchant: &Address,
+) {
+    merchant_client.register_merchant(
+        merchant,
+        &String::from_str(env, "Test Merchant"),
+        &String::from_str(env, "USD"),
+        &Some(merchant.clone()),
+        &None::<String>,
+        &None,
+    );
+    merchant_client.verify_merchant(admin, merchant);
+}
+
+fn create_and_settle(
+    env: &Env,
+    payment_client: &PaymentProcessorClient,
+    merchant: &Address,
+    payment_id: &str,
+    amount: i128,
+) {
+    payment_client.grant_role(env, &Symbol::new(env, "MERCHANT"), merchant);
+    let args = crate::CreatePaymentArgs {
+        payment_id: String::from_str(env, payment_id),
+        merchant_id: merchant.clone(),
+        payer: None,
+        amount,
+        currency: Symbol::new(env, "USDC"),
+        deposit_address: Address::generate(env),
+        expires_at: Some(env.ledger().timestamp() + 3600),
+        duration_secs: None,
+        memo: None,
+        memo_type: None,
+        token_address: None,
+        client_token: None,
+        metadata_hash: None,
+        metadata: None,
+        fee_waiver_code: None,
+    };
+    payment_client.create_payment(&args);
+
+    let tx_hash = BytesN::<32>::random(env);
+    let oracle = Address::generate(env);
+    payment_client.grant_role(env, &Symbol::new(env, "ORACLE"), &oracle);
+    payment_client.verify_payment(
+        &oracle,
+        &String::from_str(env, payment_id),
+        &tx_hash,
+        &Address::generate(env),
+        &amount,
+    );
+
+    let operator = Address::generate(env);
+    payment_client.grant_role(env, &Symbol::new(env, "SETTLEMENT_OPERATOR"), &operator);
+    let splits = soroban_sdk::vec![
+        env,
+        crate::SettlementSplit {
+            recipient: merchant.clone(),
+            amount,
+        },
+    ];
+    payment_client.settle_payment(&operator, &String::from_str(env, payment_id), &splits);
+}
+
+/* ------------------------------------------------------------------ */
+/*  SettlementSchedule config                                          */
+/* ------------------------------------------------------------------ */
+
+#[test]
+fn test_settlement_schedule_defaults_to_manual() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, _payment_client, merchant_client, merchant) = setup(&env);
+
+    register_merchant(&env, &admin, &merchant_client, &merchant);
+
+    let info = merchant_client.get_merchant(&merchant);
+    assert_eq!(info.settlement_schedule, SettlementSchedule::Manual);
+    assert_eq!(info.last_settlement_at, None);
+}
+
+#[test]
+fn test_settlement_schedule_can_be_changed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, _payment_client, merchant_client, merchant) = setup(&env);
+
+    register_merchant(&env, &admin, &merchant_client, &merchant);
+
+    merchant_client.set_settlement_schedule(&merchant, &SettlementSchedule::Daily);
+
+    let info = merchant_client.get_merchant(&merchant);
+    assert_eq!(info.settlement_schedule, SettlementSchedule::Daily);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Pending settlement accumulation                                    */
+/* ------------------------------------------------------------------ */
+
+#[test]
+fn test_pending_settlement_accumulates_on_settle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, merchant_client, merchant) = setup(&env);
+
+    register_merchant(&env, &admin, &merchant_client, &merchant);
+
+    create_and_settle(&env, &payment_client, &merchant, "PAY_SETTLE_001", 1000);
+
+    let pending = merchant_client.get_pending_settlement(&merchant);
+    assert_eq!(pending, 1000);
+}
+
+#[test]
+fn test_pending_settlement_multiple_payments() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, merchant_client, merchant) = setup(&env);
+
+    register_merchant(&env, &admin, &merchant_client, &merchant);
+
+    create_and_settle(&env, &payment_client, &merchant, "PAY_001", 500);
+    create_and_settle(&env, &payment_client, &merchant, "PAY_002", 300);
+
+    let pending = merchant_client.get_pending_settlement(&merchant);
+    assert_eq!(pending, 800);
+}
+
+/* ------------------------------------------------------------------ */
+/*  trigger_settlement                                                 */
+/* ------------------------------------------------------------------ */
+
+#[test]
+fn test_trigger_settlement_manual_settles_immediately() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, merchant_client, merchant) = setup(&env);
+
+    // Register merchant with payout address
+    merchant_client.register_merchant(
+        &merchant,
+        &String::from_str(&env, "Test Merchant"),
+        &String::from_str(&env, "USD"),
+        &Some(merchant.clone()),
+        &None::<String>,
+        &None,
+    );
+    merchant_client.verify_merchant(&admin, &merchant);
+
+    create_and_settle(&env, &payment_client, &merchant, "PAY_TRIGGER", 2000000);
+
+    let operator = Address::generate(&env);
+    payment_client.grant_role(&env, &Symbol::new(&env, "SETTLEMENT_OPERATOR"), &operator);
+
+    let swept = payment_client.trigger_settlement(&operator, &merchant);
+    assert!(swept >= 2000000);
+
+    let pending = merchant_client.get_pending_settlement(&merchant);
+    assert_eq!(pending, 0);
+}
+
+#[test]
+fn test_trigger_settlement_daily_enforces_interval() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, merchant_client, merchant) = setup(&env);
+
+    merchant_client.register_merchant(
+        &merchant,
+        &String::from_str(&env, "Test Merchant"),
+        &String::from_str(&env, "USD"),
+        &Some(merchant.clone()),
+        &None::<String>,
+        &None,
+    );
+    merchant_client.verify_merchant(&admin, &merchant);
+
+    // Set to daily schedule.
+    merchant_client.set_settlement_schedule(&merchant, &SettlementSchedule::Daily);
+
+    create_and_settle(&env, &payment_client, &merchant, "PAY_DAILY", 2000000);
+
+    let operator = Address::generate(&env);
+    payment_client.grant_role(&env, &Symbol::new(&env, "SETTLEMENT_OPERATOR"), &operator);
+
+    // First settlement succeeds.
+    let swept = payment_client.trigger_settlement(&operator, &merchant);
+    assert!(swept >= 2000000);
+
+    // Immediate second settlement should fail (daily interval not elapsed).
+    let result = payment_client.try_trigger_settlement(&operator, &merchant);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_trigger_settlement_below_min_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, payment_client, merchant_client, merchant) = setup(&env);
+
+    merchant_client.register_merchant(
+        &merchant,
+        &String::from_str(&env, "Test Merchant"),
+        &String::from_str(&env, "USD"),
+        &Some(merchant.clone()),
+        &None::<String>,
+        &None,
+    );
+    merchant_client.verify_merchant(&admin, &merchant);
+
+    // Settle a very small amount (below SETTLEMENT_MIN_AMOUNT = 1_000_000).
+    create_and_settle(&env, &payment_client, &merchant, "PAY_SMALL", 500);
+
+    let operator = Address::generate(&env);
+    payment_client.grant_role(&env, &Symbol::new(&env, "SETTLEMENT_OPERATOR"), &operator);
+
+    let result = payment_client.try_trigger_settlement(&operator, &merchant);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}


### PR DESCRIPTION
Implement merchant settlement schedule configuration as specified in issue #480.

## Changes

### Merchant struct ()
- New `SettlementSchedule` enum: `Daily | Weekly | Manual`
- New `settlement_schedule: SettlementSchedule` field (defaults to `Manual`)
- New `last_settlement_at: Option<u64>` field

### Admin/merchant config
- `set_settlement_schedule(merchant, schedule)` — merchant can change their own schedule
- `get_pending_settlement(merchant)` — read accumulated pending balance
- `add_pending_settlement(merchant, amount)` — called by `settle_payment`
- `clear_pending_settlement(merchant)`
- `set_last_settlement_at(merchant, timestamp)`

### Storage
- `DataKey::MerchantPendingSettlement(Address)` — accumulates net merchant amounts on each settle

### `settle_payment` (PaymentProcessor)
- After marking payment as `Settled`, adds the merchant's net split amount to their pending settlement balance via `add_pending_settlement`

### `trigger_settlement(operator, merchant_id)`
- Only settlement operators can trigger
- Reads pending balance from registry, checks minimum amount (`SETTLEMENT_MIN_AMOUNT = 1_000_000 = 0.1 USDC`)
- For `Daily` schedule: enforces 24h interval since `last_settlement_at`
- For `Weekly` schedule: enforces 7d interval
- For `Manual`: no interval check
- Transfers USDC from contract to merchant's `payout_address`
- Clears pending balance, updates `last_settlement_at`
- Emits `MERCHANT/SETTLEMENT_TRIGGERED` event with the swept amount

## Tests (6)

| Test | Assertion |
|---|---|
| `test_settlement_schedule_defaults_to_manual` | Default schedule is Manual |
| `test_settlement_schedule_can_be_changed` | Set to Daily, read back |
| `test_pending_settlement_accumulates_on_settle` | Single payment adds to pending |
| `test_pending_settlement_multiple_payments` | Multiple payments sum correctly |
| `test_trigger_settlement_manual_settles_immediately` | Manual trigger succeeds |
| `test_trigger_settlement_daily_enforces_interval` | Immediate second trigger fails |
| `test_trigger_settlement_below_min_rejected` | Below min amount rejected |

Closes #480