### PR TITLE
feat: metadata limits, subscription cancel proration, link URLs, FX batch rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Fluxapay solves this by enabling _USDC-in → fiat-out_ payments with a merchant
 - Fetch payment status
 - Issue refunds (where supported)
 - Manage customers & metadata
+  - **Metadata limits:** ≤20 keys; each key ≤64 chars; each value ≤256 chars
+  - Violations return `MetadataTooLarge` / `MetadataValueTooLong`
   •⁠ ⁠*Webhooks*
 - ⁠ payment.created ⁠, ⁠ payment.pending ⁠, ⁠ payment.confirmed ⁠, ⁠ payment.failed ⁠, ⁠ payment.settled ⁠
 
@@ -82,6 +84,7 @@ Fluxapay solves this by enabling _USDC-in → fiat-out_ payments with a merchant
 •⁠ ⁠*Payment Links*
 
 - Shareable links for quick checkout (social commerce, WhatsApp, Instagram, etc.)
+- Optional `base_url` builds `{base_url}/pay/{link_id}` as `shareable_url` (QR-ready)
   •⁠ ⁠*Invoices*
 - Generate invoices with payment links and track payment status
 - Perfect for freelancers, agencies, and B2B billing

--- a/fluxapay/src/fx_oracle.rs
+++ b/fluxapay/src/fx_oracle.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, String, Symbol};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec,
+};
 
 use crate::access_control::{role_admin, role_oracle, AccessControl};
 
@@ -7,6 +9,9 @@ const MAX_RATE_AGE_SECS: u64 = 86_400; // 24 hours
 
 /// Maximum ledger sequence gap since last rate update (~24 h at ~5 s/ledger).
 const MAX_LEDGER_GAP: u32 = 17_280;
+
+/// Maximum number of currency pairs accepted by `set_rates_batch`.
+const MAX_BATCH_RATES: u32 = 20;
 
 #[contract]
 pub struct FXOracle;
@@ -27,6 +32,8 @@ pub enum FXOracleError {
     RateNotFound = 1,
     RateStale = 2,
     Unauthorized = 3,
+    /// Batch rate update exceeds the maximum of 20 pairs.
+    BatchTooLarge = 4,
 }
 
 #[contracttype]
@@ -83,6 +90,49 @@ impl FXOracle {
             return Err(FXOracleError::Unauthorized);
         }
 
+        Self::store_rate(&env, pair.clone(), rate, decimals);
+
+        // Emit event: (RATE, UPDATED), pair
+        env.events().publish(
+            (Symbol::new(&env, "RATE"), Symbol::new(&env, "UPDATED")),
+            pair,
+        );
+
+        Ok(())
+    }
+
+    /// Atomically update up to 20 currency pairs. Requires the ORACLE role.
+    ///
+    /// Emits `RATE/BATCH_UPDATED` with the number of pairs updated.
+    pub fn set_rates_batch(
+        env: Env,
+        operator: Address,
+        rates: Vec<(Symbol, i128, u32)>,
+    ) -> Result<u32, FXOracleError> {
+        operator.require_auth();
+
+        if !AccessControl::has_role(&env, &role_oracle(&env), &operator) {
+            return Err(FXOracleError::Unauthorized);
+        }
+
+        if rates.len() > MAX_BATCH_RATES {
+            return Err(FXOracleError::BatchTooLarge);
+        }
+
+        let count = rates.len();
+        for (pair, rate, decimals) in rates.iter() {
+            Self::store_rate(&env, pair, rate, decimals);
+        }
+
+        env.events().publish(
+            (Symbol::new(&env, "RATE"), Symbol::new(&env, "BATCH_UPDATED")),
+            count,
+        );
+
+        Ok(count)
+    }
+
+    fn store_rate(env: &Env, pair: Symbol, rate: i128, decimals: u32) {
         let rate_data = RateData {
             pair: pair.clone(),
             rate,
@@ -93,15 +143,7 @@ impl FXOracle {
 
         env.storage()
             .persistent()
-            .set(&OracleDataKey::Rate(pair.clone()), &rate_data);
-
-        // Emit event: (RATE, UPDATED), pair
-        env.events().publish(
-            (Symbol::new(&env, "RATE"), Symbol::new(&env, "UPDATED")),
-            pair,
-        );
-
-        Ok(())
+            .set(&OracleDataKey::Rate(pair), &rate_data);
     }
 
     pub fn get_rate(env: Env, pair: Symbol) -> Result<RateData, FXOracleError> {
@@ -114,6 +156,29 @@ impl FXOracle {
         Self::check_rate_freshness(&env, &rate_data, &pair)?;
 
         Ok(rate_data)
+    }
+
+    /// Permissionless staleness probe. Returns `true` when the rate is stale
+    /// (or missing) and emits `RATE/STALE_ALERT` when stale data is present.
+    pub fn check_rate_staleness(env: Env, pair: Symbol) -> bool {
+        let rate_data: RateData = match env
+            .storage()
+            .persistent()
+            .get(&OracleDataKey::Rate(pair.clone()))
+        {
+            Some(data) => data,
+            None => return true,
+        };
+
+        if Self::is_rate_stale(&env, &rate_data) {
+            env.events().publish(
+                (Symbol::new(&env, "RATE"), Symbol::new(&env, "STALE_ALERT")),
+                pair,
+            );
+            true
+        } else {
+            false
+        }
     }
 
     // SECURITY: Rate freshness relies on ledger wall-clock time (`env.ledger().timestamp()`),
@@ -133,6 +198,23 @@ impl FXOracle {
         rate_data: &RateData,
         pair: &Symbol,
     ) -> Result<(), FXOracleError> {
+        if Self::is_rate_stale(env, rate_data) {
+            let ledger_gap = env
+                .ledger()
+                .sequence()
+                .saturating_sub(rate_data.updated_sequence);
+            if ledger_gap > MAX_LEDGER_GAP {
+                env.events().publish(
+                    (Symbol::new(env, "RATE"), Symbol::new(env, "STALE_ALERT")),
+                    pair.clone(),
+                );
+            }
+            return Err(FXOracleError::RateStale);
+        }
+        Ok(())
+    }
+
+    fn is_rate_stale(env: &Env, rate_data: &RateData) -> bool {
         let configured_threshold: u64 = env
             .storage()
             .instance()
@@ -143,22 +225,14 @@ impl FXOracle {
 
         let now = env.ledger().timestamp();
         if now > rate_data.updated_at.saturating_add(effective_threshold) {
-            return Err(FXOracleError::RateStale);
+            return true;
         }
 
         let ledger_gap = env
             .ledger()
             .sequence()
             .saturating_sub(rate_data.updated_sequence);
-        if ledger_gap > MAX_LEDGER_GAP {
-            env.events().publish(
-                (Symbol::new(env, "RATE"), Symbol::new(env, "STALE_ALERT")),
-                pair.clone(),
-            );
-            return Err(FXOracleError::RateStale);
-        }
-
-        Ok(())
+        ledger_gap > MAX_LEDGER_GAP
     }
 
     pub fn get_settlement_amount(

--- a/fluxapay/src/fx_oracle_test.rs
+++ b/fluxapay/src/fx_oracle_test.rs
@@ -183,3 +183,85 @@ fn test_get_fx_admin_before_initialization_returns_none() {
 
     assert_eq!(client.get_fx_admin(), None);
 }
+
+#[test]
+fn test_check_rate_staleness_emits_alert() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_oracle(&env);
+
+    let oracle = Address::generate(&env);
+    client.oracle_grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+
+    let pair = Symbol::new(&env, "USDC_NGN");
+    client.set_rate(&oracle, &pair, &1500i128, &0);
+
+    assert!(!client.check_rate_staleness(&pair));
+
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 25 * 3600);
+
+    // Stale → returns true (and emits RATE/STALE_ALERT on-chain).
+    assert!(client.check_rate_staleness(&pair));
+}
+
+#[test]
+fn test_set_rates_batch_stores_all_rates() {
+    use soroban_sdk::vec;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_oracle(&env);
+
+    let oracle = Address::generate(&env);
+    client.oracle_grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+
+    let rates = vec![
+        &env,
+        (Symbol::new(&env, "USD"), 1_0000000i128, 7u32),
+        (Symbol::new(&env, "NGN"), 1500_0000000i128, 7u32),
+        (Symbol::new(&env, "EUR"), 9200000i128, 7u32),
+    ];
+
+    let count = client.set_rates_batch(&oracle, &rates);
+    assert_eq!(count, 3);
+
+    assert_eq!(client.get_rate(&Symbol::new(&env, "USD")).rate, 1_0000000i128);
+    assert_eq!(client.get_rate(&Symbol::new(&env, "NGN")).rate, 1500_0000000i128);
+    assert_eq!(client.get_rate(&Symbol::new(&env, "EUR")).rate, 9200000i128);
+}
+
+#[test]
+fn test_set_rates_batch_rejects_non_oracle() {
+    use soroban_sdk::vec;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup_oracle(&env);
+
+    let unauthorized = Address::generate(&env);
+    let rates = vec![&env, (Symbol::new(&env, "USD"), 1i128, 0u32)];
+
+    let result = client.try_set_rates_batch(&unauthorized, &rates);
+    assert_eq!(result, Err(Ok(FXOracleError::Unauthorized)));
+}
+
+#[test]
+fn test_set_rates_batch_rejects_oversized_batch() {
+    use soroban_sdk::vec;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup_oracle(&env);
+
+    let oracle = Address::generate(&env);
+    client.oracle_grant_role(&admin, &Symbol::new(&env, "ORACLE"), &oracle);
+
+    let mut rates = vec![&env];
+    for _ in 0..21u32 {
+        rates.push_back((Symbol::new(&env, "USD"), 1i128, 0u32));
+    }
+
+    let result = client.try_set_rates_batch(&oracle, &rates);
+    assert_eq!(result, Err(Ok(FXOracleError::BatchTooLarge)));
+}

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -687,6 +687,8 @@ pub enum DataKey {
     /// Admin-managed reusable fee-waiver code registry for per-payment promotions.
     /// Keyed by the code string itself.
     FeeWaiverCode(String),
+    /// When true, `cancel_subscription` may create a prorated pending refund.
+    AllowProratedRefunds,
 }
 
 /// Default initial contract version string.
@@ -3409,10 +3411,16 @@ impl RefundManager {
         Ok(())
     }
 
+    /// Cancel a subscription and optionally create a prorated pending refund.
+    ///
+    /// When `refund_remaining` is true, a payment was made in the current billing
+    /// period, and the admin policy `allow_prorated_refunds` is enabled, a pending
+    /// refund is created for the unused portion of the period (by whole days).
     pub fn cancel_subscription(
         env: Env,
         payer: Address,
         subscription_id: String,
+        refund_remaining: bool,
     ) -> Result<(), Error> {
         payer.require_auth();
 
@@ -3422,12 +3430,49 @@ impl RefundManager {
             return Err(Error::Unauthorized);
         }
 
+        if subscription.status == SubscriptionStatus::Cancelled {
+            return Err(Error::PaymentAlreadyProcessed);
+        }
+
+        let now = env.ledger().timestamp();
+        let allow_proration: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AllowProratedRefunds)
+            .unwrap_or(false);
+
+        if refund_remaining && allow_proration {
+            if let Some(last_paid) = subscription.last_payment_at {
+                // Payment must fall within the current open period.
+                if last_paid < subscription.next_payment_at && now < subscription.next_payment_at {
+                    let secs_remaining = subscription.next_payment_at.saturating_sub(now);
+                    let days_remaining = secs_remaining / 86_400;
+                    let period_days = core::cmp::max(1, subscription.interval_secs / 86_400);
+
+                    if days_remaining > 0 {
+                        let prorated = subscription
+                            .amount
+                            .saturating_mul(days_remaining as i128)
+                            / (period_days as i128);
+
+                        if prorated > 0 {
+                            Self::create_subscription_prorated_refund(
+                                &env,
+                                &subscription,
+                                prorated,
+                            )?;
+                        }
+                    }
+                }
+            }
+        }
+
         subscription.status = SubscriptionStatus::Cancelled;
         env.storage()
             .persistent()
             .set(&DataKey::Subscription(subscription_id.clone()), &subscription);
 
-        // Issue #302: Remove from ActiveSubscriptions index
+        // Stop future tick billing
         Self::remove_active_subscription(&env, &subscription_id);
 
         env.events().publish(
@@ -3436,6 +3481,116 @@ impl RefundManager {
         );
 
         Ok(())
+    }
+
+    /// Admin policy: enable or disable prorated refunds on subscription cancel.
+    pub fn set_allow_prorated_refunds(
+        env: Env,
+        admin: Address,
+        allow: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllowProratedRefunds, &allow);
+        Ok(())
+    }
+
+    /// Query whether prorated subscription refunds are allowed.
+    pub fn get_allow_prorated_refunds(env: Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AllowProratedRefunds)
+            .unwrap_or(false)
+    }
+
+    /// Create a pending refund backed by a synthetic confirmed payment for the
+    /// last subscription billing period. Emits `REFUND/AUTO_CREATED`.
+    fn create_subscription_prorated_refund(
+        env: &Env,
+        subscription: &Subscription,
+        refund_amount: i128,
+    ) -> Result<String, Error> {
+        let tick_id = Self::get_next_subscription_tick_id(env);
+        let payment_id = format_id(env, "sub_pr_", tick_id);
+        let now = env.ledger().timestamp();
+        let last_paid = subscription.last_payment_at.unwrap_or(now);
+
+        let payment = PaymentCharge {
+            payment_id: payment_id.clone(),
+            merchant_id: subscription.merchant_id.clone(),
+            amount: subscription.amount,
+            currency: subscription.currency.clone(),
+            deposit_address: env.current_contract_address(),
+            status: PaymentStatus::Confirmed,
+            payer_address: Some(subscription.payer_address.clone()),
+            transaction_hash: None,
+            created_at: last_paid,
+            confirmed_at: Some(last_paid),
+            expires_at: subscription.next_payment_at,
+            amount_received: Some(subscription.amount),
+            memo: None,
+            memo_type: None,
+            token_address: None,
+            metadata_hash: None,
+            original_token: None,
+            swap_path: None,
+            fx_rate: None,
+            fx_rate_at: None,
+            metadata: None,
+            fee_waiver_code: None,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Payment(payment_id.clone()), &payment);
+        Self::bump_payment_ttl(env, &payment_id, &payment.status);
+
+        let counter = Self::get_next_refund_id(env);
+        let refund_id = format_id(env, "refund_", counter);
+        let reason = String::from_str(env, "Prorated subscription cancellation");
+
+        let refund = Refund {
+            refund_id: refund_id.clone(),
+            payment_id: payment_id.clone(),
+            amount: refund_amount,
+            reason,
+            status: RefundStatus::Pending,
+            requester: subscription.payer_address.clone(),
+            created_at: now,
+            processed_at: None,
+            approved: false,
+            receipt_hash: None,
+            expiry_at: now + REFUND_EXPIRY_SECS,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Refund(refund_id.clone()), &refund);
+
+        let mut payment_refunds = Self::get_payment_refunds_internal(env, &payment_id);
+        payment_refunds.push_back(refund_id.clone());
+        env.storage().persistent().set(
+            &DataKey::PaymentRefunds(payment_id.clone()),
+            &payment_refunds,
+        );
+        Self::bump_ttl(env, &DataKey::PaymentRefunds(payment_id.clone()), LONG_LIVE_TTL);
+        Self::bump_refund_ttl(env, &refund_id, &refund.status);
+
+        env.events().publish(
+            (Symbol::new(env, "REFUND"), Symbol::new(env, "AUTO_CREATED")),
+            (
+                payment_id,
+                refund_id.clone(),
+                refund_amount,
+                subscription.subscription_id.clone(),
+            ),
+        );
+
+        Ok(refund_id)
     }
 
     /// Submit usage metrics for a metered subscription.
@@ -4651,16 +4806,9 @@ impl PaymentProcessor {
             return Err(Error::InvalidPaymentId);
         }
 
-        // Issue #286: Validate metadata constraints
+        // Validate metadata key count and key/value length limits.
         if let Some(ref meta_map) = args.metadata {
-            if meta_map.len() > 20 {
-                return Err(Error::MetadataTooLarge);
-            }
-            for (_, value) in meta_map.iter() {
-                if value.len() > 256 {
-                    return Err(Error::MetadataValueTooLong);
-                }
-            }
+            utils::validate_metadata(meta_map)?;
         }
 
         // Issue #397: Validate Stellar memo type constraints.
@@ -4858,16 +5006,9 @@ impl PaymentProcessor {
                 return Err(Error::InvalidPaymentId);
             }
 
-            // Issue #286: Validate metadata constraints
+            // Validate metadata key count and key/value length limits.
             if let Some(ref meta_map) = args.metadata {
-                if meta_map.len() > 20 {
-                    return Err(Error::MetadataTooLarge);
-                }
-                for (_, value) in meta_map.iter() {
-                    if value.len() > 256 {
-                        return Err(Error::MetadataValueTooLong);
-                    }
-                }
+                utils::validate_metadata(meta_map)?;
             }
 
             // Check idempotency
@@ -5573,7 +5714,10 @@ impl PaymentProcessor {
                     if now < record.expires_at && record.remaining_uses > 0 {
                         record.remaining_uses = record.remaining_uses.saturating_sub(1);
                         env.storage().persistent().set(&key, &record);
-                        Some(String::from_str(&env, "code_waiver:").concat(&code))
+                        Some(crate::utils::concat_strings(
+                            &env,
+                            &[String::from_str(&env, "code_waiver:"), code.clone()],
+                        ))
                     } else {
                         None
                     }
@@ -7084,7 +7228,8 @@ mod payment_link;
 #[cfg(test)]
 mod proptests;
 pub use payment_link::{
-    FiatConfig, MaybeFiatConfig, PaymentLink, PaymentLinkManager, PaymentLinkManagerClient,
+    FiatConfig, LinkAnalytics, MaybeFiatConfig, PaymentLink, PaymentLinkManager,
+    PaymentLinkManagerClient,
 };
 #[cfg(test)]
 mod memo_test;

--- a/fluxapay/src/merchant_registry.rs
+++ b/fluxapay/src/merchant_registry.rs
@@ -1442,6 +1442,30 @@ impl MerchantRegistry {
         env: Env,
         merchant_id: Address,
         anchor_config: Option<AnchorConfig>,
+    ) -> Result<(), MerchantError> {
+        merchant_id.require_auth();
+
+        let mut merchant = Self::get_merchant_internal(&env, &merchant_id)?;
+        let domain_for_event = match &anchor_config {
+            Some(cfg) => cfg.anchor_domain.clone(),
+            None => String::from_str(&env, ""),
+        };
+        merchant.anchor_config = MaybeAnchorConfig::from(anchor_config);
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::Merchant(merchant_id.clone()), &merchant);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "MERCHANT"),
+                Symbol::new(&env, "ANCHOR_UPDATED"),
+            ),
+            (merchant_id, domain_for_event),
+        );
+
+        Ok(())
+    }
+
     /// Enable/disable whitelist mode for a merchant (issue #516).
     /// Only Business-tier merchants may enable whitelist mode.
     pub fn set_merchant_whitelist_mode(
@@ -1452,8 +1476,6 @@ impl MerchantRegistry {
         merchant_id.require_auth();
 
         let mut merchant = Self::get_merchant_internal(&env, &merchant_id)?;
-        merchant.anchor_config = MaybeAnchorConfig::from(anchor_config.clone());
-
 
         if enabled && merchant.kyc_tier != KycTier::Business {
             return Err(MerchantError::WhitelistModeRequiresBusinessTier);
@@ -1513,6 +1535,11 @@ impl MerchantRegistry {
         env.events().publish(
             (Symbol::new(&env, "MERCHANT"), Symbol::new(&env, "FEE_WAIVER_SET")),
             (merchant_id, expires_at_for_event),
+        );
+
+        Ok(())
+    }
+
     /// Add a customer address to the merchant's payment whitelist (issue #516).
     pub fn add_to_customer_whitelist(
         env: Env,

--- a/fluxapay/src/payment_link.rs
+++ b/fluxapay/src/payment_link.rs
@@ -3,7 +3,8 @@ use soroban_sdk::{
     Symbol, Vec,
 };
 
-use crate::{PaymentCharge, PaymentStatus, format_id};
+use crate::utils;
+use crate::{format_id, PaymentCharge, PaymentStatus};
 
 /// Multi-currency fiat configuration for payment links (issue #413).
 #[contracttype]
@@ -65,6 +66,8 @@ pub struct PaymentLink {
     pub metadata: Option<Map<String, String>>,
     /// Fiat configuration for multi-currency invoicing (issue #413).
     pub fiat: MaybeFiatConfig,
+    /// Canonical shareable checkout URL: `{base_url}/pay/{link_id}`.
+    pub shareable_url: Option<String>,
 }
 
 /// Analytics summary for a payment link.
@@ -90,6 +93,8 @@ pub enum LinkDataKey {
     LinkPayments(String),
     /// Individual payment charge created from a link
     LinkPayment(String),
+    /// Admin-configured default base URL for shareable payment links.
+    PaymentBaseUrl,
 }
 
 #[contract]
@@ -139,6 +144,37 @@ impl PaymentLinkManager {
         Ok(())
     }
 
+    /// Set the default base URL used when `create_link` omits `base_url`.
+    pub fn set_payment_base_url(
+        env: Env,
+        admin: Address,
+        url: String,
+    ) -> Result<(), crate::Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&LinkDataKey::LinkAdmin)
+            .ok_or(crate::Error::Unauthorized)?;
+
+        if admin != stored_admin {
+            return Err(crate::Error::Unauthorized);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&LinkDataKey::PaymentBaseUrl, &url);
+        Ok(())
+    }
+
+    /// Return the admin-configured default payment base URL, if any.
+    pub fn get_payment_base_url(env: Env) -> Option<String> {
+        env.storage()
+            .persistent()
+            .get(&LinkDataKey::PaymentBaseUrl)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn create_link(
         env: Env,
@@ -152,19 +188,30 @@ impl PaymentLinkManager {
         direct_transfer: bool,
         metadata: Option<Map<String, String>>,
         fiat: MaybeFiatConfig,
+        base_url: Option<String>,
     ) -> Result<String, crate::Error> {
         merchant.require_auth();
 
         if let Some(ref meta_map) = metadata {
-            if meta_map.len() > 20 {
-                return Err(crate::Error::MetadataTooLarge);
-            }
-            for (_, value) in meta_map.iter() {
-                if value.len() > 256 {
-                    return Err(crate::Error::MetadataValueTooLong);
-                }
-            }
+            utils::validate_metadata(meta_map)?;
         }
+
+        let resolved_base = base_url.or_else(|| {
+            env.storage()
+                .persistent()
+                .get(&LinkDataKey::PaymentBaseUrl)
+        });
+
+        let shareable_url = resolved_base.map(|base| {
+            utils::concat_strings(
+                &env,
+                &[
+                    base,
+                    String::from_str(&env, "/pay/"),
+                    link_id.clone(),
+                ],
+            )
+        });
 
         let link = PaymentLink {
             link_id: link_id.clone(),
@@ -181,6 +228,7 @@ impl PaymentLinkManager {
             direct_transfer,
             metadata,
             fiat,
+            shareable_url,
         };
 
         env.storage()
@@ -194,6 +242,13 @@ impl PaymentLinkManager {
         );
 
         Ok(link_id)
+    }
+
+    /// Return the shareable URL for a link, if one was stored.
+    pub fn get_link_url(env: Env, link_id: String) -> Option<String> {
+        Self::get_link_internal(&env, &link_id)
+            .ok()
+            .and_then(|link| link.shareable_url)
     }
 
     /// Record a view of a payment link.
@@ -304,7 +359,7 @@ impl PaymentLinkManager {
         // Issue #111: If direct_transfer is true, transfer funds directly to the merchant,
         // bypassing the escrow/platform wallet.
         if link.direct_transfer {
-            let token_address = usdc_token.ok_or(crate::Error::Unauthorized)?;
+            let token_address = usdc_token.clone().ok_or(crate::Error::Unauthorized)?;
             let token_client = token::TokenClient::new(&env, &token_address);
             let merchant_muxed: MuxedAddress = (&link.merchant_id).into();
             token_client.transfer(&payer, &merchant_muxed, &resolved_amount);
@@ -337,6 +392,7 @@ impl PaymentLinkManager {
             fx_rate: None,
             fx_rate_at: None,
             metadata: link.metadata.clone(),
+            fee_waiver_code: None,
         };
 
         // Store the payment charge

--- a/fluxapay/src/payment_link_test.rs
+++ b/fluxapay/src/payment_link_test.rs
@@ -38,6 +38,7 @@ fn test_create_link() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     assert_eq!(id, link_id);
@@ -68,6 +69,7 @@ fn test_use_link_fixed_amount() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     let payment_id = client.use_link(&payer, &link_id, &amount, &None);
@@ -97,6 +99,7 @@ fn test_use_link_wrong_amount() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     client.use_link(&payer, &link_id, &500i128, &None);
@@ -121,6 +124,7 @@ fn test_use_link_open_amount() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     client.use_link(&payer, &link_id, &1500i128, &None);
@@ -146,6 +150,7 @@ fn test_deactivate_link() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     client.deactivate_link(&merchant, &link_id);
@@ -174,6 +179,7 @@ fn test_link_expired() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     env.ledger().set_timestamp(expiry + 1);
@@ -200,6 +206,7 @@ fn test_verify_batch_returns_status_for_active_links() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
     client.create_link(
         &merchant,
@@ -212,6 +219,7 @@ fn test_verify_batch_returns_status_for_active_links() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     let results = client.verify_batch(&vec![&env, link_id1.clone(), link_id2.clone()]);
@@ -240,6 +248,7 @@ fn test_verify_batch_handles_missing_links() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     let results = client.verify_batch(&vec![&env, existing_link.clone(), missing_link.clone()]);
@@ -266,6 +275,7 @@ fn test_verify_batch_returns_inactive_for_deactivated_link() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     client.deactivate_link(&merchant, &link_id);
@@ -305,6 +315,7 @@ fn test_max_uses() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     client.use_link(&payer, &link_id, &100i128, &None);
@@ -344,6 +355,7 @@ fn test_direct_transfer_link_transfers_to_merchant() {
         &true,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     let link = client.get_link(&link_id);
@@ -379,6 +391,7 @@ fn test_direct_transfer_without_token_address_fails() {
         &true,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     // Should fail because usdc_token is None but direct_transfer is true
@@ -415,6 +428,7 @@ fn test_metadata_too_large_21_keys() {
         &false,
         &Some(metadata),
         &MaybeFiatConfig::None,
+        &None,
     );
 }
 
@@ -441,6 +455,7 @@ fn test_metadata_value_too_long_257_chars() {
         &false,
         &Some(metadata),
         &MaybeFiatConfig::None,
+        &None,
     );
 }
 
@@ -472,6 +487,7 @@ fn test_metadata_20_keys_256_char_values_succeeds() {
         &false,
         &Some(metadata),
         &MaybeFiatConfig::None,
+        &None,
     );
 
     assert_eq!(id, link_id);
@@ -497,6 +513,7 @@ fn test_metadata_none_succeeds() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     assert_eq!(id, link_id);
@@ -543,6 +560,7 @@ fn test_create_fiat_link_and_use_with_rate() {
         &false,
         &None,
         &MaybeFiatConfig::Some(fiat),
+        &None,
     );
 
     assert_eq!(id, link_id);
@@ -589,6 +607,7 @@ fn test_use_fiat_link_requires_correct_usdc() {
         &false,
         &None,
         &MaybeFiatConfig::Some(fiat),
+        &None,
     );
 
     // Should succeed with correct USDC equivalent (50 * 10^7 / 2_0000000 = 25)
@@ -634,6 +653,7 @@ fn test_use_fiat_link_rejects_wrong_usdc() {
         &false,
         &None,
         &MaybeFiatConfig::Some(fiat),
+        &None,
     );
 
     // 50 USDC is wrong when fiat_amount=100 at rate=1
@@ -660,6 +680,7 @@ fn test_record_link_view_increments_view_count() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     // Initially zero views
@@ -695,6 +716,7 @@ fn test_use_link_accumulates_revenue() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     // Initially zero revenue
@@ -733,6 +755,7 @@ fn test_get_link_analytics_conversion_rate() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     // Record 10 views
@@ -771,6 +794,7 @@ fn test_get_link_analytics_zero_views() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     // Use the link without any views
@@ -804,6 +828,7 @@ fn test_get_link_analytics_full_conversion() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     // 4 views, 4 uses → 100% conversion = 10000 bps
@@ -839,6 +864,7 @@ fn test_record_link_view_rejects_inactive_link() {
         &false,
         &None,
         &MaybeFiatConfig::None,
+        &None,
     );
 
     client.deactivate_link(&merchant, &link_id);
@@ -855,6 +881,126 @@ fn test_get_link_analytics_not_found() {
 
     let nonexistent = String::from_str(&env, "does_not_exist");
     client.get_link_analytics(&nonexistent);
+}
+
+#[test]
+fn test_create_link_with_base_url_sets_shareable_url() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (merchant, client) = setup_payment_link(&env);
+
+    let link_id = String::from_str(&env, "share_link");
+    let base = String::from_str(&env, "https://pay.fluxapay.app");
+    client.create_link(
+        &merchant,
+        &link_id,
+        &Some(1000i128),
+        &Symbol::new(&env, "USDC"),
+        &String::from_str(&env, "Shareable"),
+        &None,
+        &None,
+        &false,
+        &None,
+        &MaybeFiatConfig::None,
+        &Some(base),
+    );
+
+    let expected = String::from_str(&env, "https://pay.fluxapay.app/pay/share_link");
+    let link = client.get_link(&link_id);
+    assert_eq!(link.shareable_url, Some(expected.clone()));
+    assert_eq!(client.get_link_url(&link_id), Some(expected));
+}
+
+#[test]
+fn test_create_link_without_base_url_returns_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (merchant, client) = setup_payment_link(&env);
+
+    let link_id = String::from_str(&env, "no_base_link");
+    client.create_link(
+        &merchant,
+        &link_id,
+        &Some(1000i128),
+        &Symbol::new(&env, "USDC"),
+        &String::from_str(&env, "No Base"),
+        &None,
+        &None,
+        &false,
+        &None,
+        &MaybeFiatConfig::None,
+        &None,
+    );
+
+    let link = client.get_link(&link_id);
+    assert!(link.shareable_url.is_none());
+    assert!(client.get_link_url(&link_id).is_none());
+}
+
+#[test]
+fn test_set_payment_base_url_used_as_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PaymentLinkManager, ());
+    let client = PaymentLinkManagerClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    let base = String::from_str(&env, "https://checkout.example.com");
+    client.set_payment_base_url(&admin, &base);
+
+    let link_id = String::from_str(&env, "default_base");
+    client.create_link(
+        &merchant,
+        &link_id,
+        &Some(500i128),
+        &Symbol::new(&env, "USDC"),
+        &String::from_str(&env, "Default Base"),
+        &None,
+        &None,
+        &false,
+        &None,
+        &MaybeFiatConfig::None,
+        &None,
+    );
+
+    assert_eq!(
+        client.get_link_url(&link_id),
+        Some(String::from_str(
+            &env,
+            "https://checkout.example.com/pay/default_base"
+        ))
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #47)")]
+fn test_create_link_metadata_key_too_long() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (merchant, client) = setup_payment_link(&env);
+
+    let long_key = String::from_str(
+        &env,
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    );
+    let mut metadata: Map<String, String> = Map::new(&env);
+    metadata.set(long_key, String::from_str(&env, "v"));
+
+    client.create_link(
+        &merchant,
+        &String::from_str(&env, "meta_key_long"),
+        &None,
+        &Symbol::new(&env, "USDC"),
+        &String::from_str(&env, "Meta Key"),
+        &None,
+        &None,
+        &false,
+        &Some(metadata),
+        &MaybeFiatConfig::None,
+        &None,
+    );
 }
 
 

--- a/fluxapay/src/payment_metadata_test.rs
+++ b/fluxapay/src/payment_metadata_test.rs
@@ -144,6 +144,25 @@ fn test_create_payment_metadata_value_too_long() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #47)")]
+fn test_create_payment_metadata_key_too_long() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, merchant, client) = setup(&env);
+
+    // 65-char key — one over the 64-char limit
+    let long_key = String::from_str(
+        &env,
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    );
+
+    let mut meta: Map<String, String> = Map::new(&env);
+    meta.set(long_key, String::from_str(&env, "ok"));
+
+    client.create_payment(&payment_args(&env, &merchant, Some(meta)));
+}
+
+#[test]
 fn test_create_payment_metadata_in_event_payload() {
     let env = Env::default();
     env.mock_all_auths();

--- a/fluxapay/src/subscription_test.rs
+++ b/fluxapay/src/subscription_test.rs
@@ -227,7 +227,7 @@ fn test_cancel_subscription_by_payer_becomes_cancelled() {
     let payer = Address::generate(&env);
     let sub_id = client.subscribe(&payer, &plan_id, &None, &None, &None);
 
-    client.cancel_subscription(&payer, &sub_id);
+    client.cancel_subscription(&payer, &sub_id, &false);
 
     let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.status, SubscriptionStatus::Cancelled);
@@ -277,4 +277,108 @@ fn test_deactivate_subscription_plan_by_merchant_marks_inactive() {
 
     let plan = client.get_subscription_plan(&plan_id);
     assert!(!plan.active, "Plan should be inactive after deactivation");
+}
+
+/// Mid-period cancel with proration creates a pending refund and emits events.
+#[test]
+fn test_cancel_subscription_mid_period_with_proration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _merchant, plan_id) = setup_with_plan(&env);
+
+    client.set_allow_prorated_refunds(&admin, &true);
+
+    let payer = Address::generate(&env);
+    let sub_id = client.subscribe(&payer, &plan_id, &None, &None, &None);
+
+    // Simulate a successful billing tick by advancing and processing due subs.
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_oracle(&env), &operator);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 7 * 86_400);
+    assert_eq!(client.process_due_subscriptions(&operator), 1);
+
+    let sub_before = client.get_subscription(&sub_id);
+    assert!(sub_before.last_payment_at.is_some());
+
+    // Advance 3 days into the 7-day period → 4 days remaining → 4/7 of amount.
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 3 * 86_400);
+
+    client.cancel_subscription(&payer, &sub_id, &true);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::Cancelled);
+
+    // Synthetic payment + pending prorated refund must exist.
+    let payment_id = String::from_str(&env, "sub_pr_2");
+    let refunds = client.get_payment_refunds(&payment_id);
+    assert_eq!(refunds.len(), 1);
+    let refund = refunds.get(0).unwrap();
+    assert_eq!(refund.status, crate::RefundStatus::Pending);
+    // 4/7 of 1_000_000 = 571_428
+    assert_eq!(refund.amount, 571_428_i128);
+}
+
+/// Mid-period cancel without proration flag cancels but creates no refund.
+#[test]
+fn test_cancel_subscription_mid_period_without_proration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _merchant, plan_id) = setup_with_plan(&env);
+
+    client.set_allow_prorated_refunds(&admin, &true);
+
+    let payer = Address::generate(&env);
+    let sub_id = client.subscribe(&payer, &plan_id, &None, &None, &None);
+
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_oracle(&env), &operator);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 7 * 86_400);
+    assert_eq!(client.process_due_subscriptions(&operator), 1);
+
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 3 * 86_400);
+
+    client.cancel_subscription(&payer, &sub_id, &false);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::Cancelled);
+
+    let payment_id = String::from_str(&env, "sub_pr_2");
+    let refunds = client.get_payment_refunds(&payment_id);
+    assert_eq!(refunds.len(), 0);
+}
+
+/// End-of-period cancel (no days remaining) creates no prorated refund.
+#[test]
+fn test_cancel_subscription_end_of_period_no_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _merchant, plan_id) = setup_with_plan(&env);
+
+    client.set_allow_prorated_refunds(&admin, &true);
+
+    let payer = Address::generate(&env);
+    let sub_id = client.subscribe(&payer, &plan_id, &None, &None, &None);
+
+    let operator = Address::generate(&env);
+    client.grant_role(&admin, &role_oracle(&env), &operator);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 7 * 86_400);
+    assert_eq!(client.process_due_subscriptions(&operator), 1);
+
+    // Jump to exactly next_payment_at (end of period).
+    let sub_before = client.get_subscription(&sub_id);
+    env.ledger().set_timestamp(sub_before.next_payment_at);
+
+    client.cancel_subscription(&payer, &sub_id, &true);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::Cancelled);
+
+    let payment_id = String::from_str(&env, "sub_pr_2");
+    let refunds = client.get_payment_refunds(&payment_id);
+    assert_eq!(refunds.len(), 0);
 }

--- a/fluxapay/src/test.rs
+++ b/fluxapay/src/test.rs
@@ -2668,7 +2668,7 @@ fn test_cancelled_subscription_removed_from_active_index() {
     let sub_id = client.subscribe(&payer, &plan_id, &None, &None, &None);
 
     // Cancel the subscription
-    client.cancel_subscription(&payer, &sub_id);
+    client.cancel_subscription(&payer, &sub_id, &false);
 
     // Advance time past due date
     env.ledger()

--- a/fluxapay/src/utils.rs
+++ b/fluxapay/src/utils.rs
@@ -1,4 +1,26 @@
-use soroban_sdk::{Bytes, Env, String};
+use soroban_sdk::{Bytes, Env, Map, String};
+
+/// Maximum number of key/value pairs allowed in payment/link metadata.
+pub const MAX_METADATA_KEYS: u32 = 20;
+/// Maximum length of a metadata key (characters).
+pub const MAX_METADATA_KEY_LEN: u32 = 64;
+/// Maximum length of a metadata value (characters).
+pub const MAX_METADATA_VALUE_LEN: u32 = 256;
+
+/// Validate metadata map size and key/value length limits.
+///
+/// Limits: ≤20 keys, each key ≤64 chars, each value ≤256 chars.
+pub fn validate_metadata(meta_map: &Map<String, String>) -> Result<(), crate::Error> {
+    if meta_map.len() > MAX_METADATA_KEYS {
+        return Err(crate::Error::MetadataTooLarge);
+    }
+    for (key, value) in meta_map.iter() {
+        if key.len() > MAX_METADATA_KEY_LEN || value.len() > MAX_METADATA_VALUE_LEN {
+            return Err(crate::Error::MetadataValueTooLong);
+        }
+    }
+    Ok(())
+}
 
 /// Validates that a string is a valid IPFS multihash (CIDv0 or CIDv1).
 ///
@@ -102,6 +124,23 @@ pub fn format_id(env: &Env, prefix: &str, n: u64) -> String {
     // Copy into a fixed-size slice and convert to Soroban String
     let mut arr = [0u8; 64];
     let final_len = result.len().min(64);
+    for i in 0..final_len {
+        arr[i as usize] = result.get(i).unwrap();
+    }
+    String::from_bytes(env, &arr[..final_len as usize])
+}
+
+/// Concatenate Soroban strings (used for shareable payment URLs).
+pub fn concat_strings(env: &Env, parts: &[String]) -> String {
+    let mut result = Bytes::new(env);
+    for part in parts {
+        let bytes = part.to_bytes();
+        for i in 0..bytes.len() {
+            result.push_back(bytes.get(i).unwrap());
+        }
+    }
+    let final_len = result.len().min(512);
+    let mut arr = [0u8; 512];
     for i in 0..final_len {
         arr[i as usize] = result.get(i).unwrap();
     }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -270,9 +270,20 @@ const linkId = await client.createLink({
   merchant: "G...",
   amount: 5_000_000n, // 0.5 USDC (7 decimals)
   usdcToken: "C...",
+  // metadata: ≤20 keys; key ≤64 chars; value ≤256 chars
   metadata: { product: "Coffee", ref: "order_42" }, // optional
+  baseUrl: "https://pay.example.com", // optional → shareable_url
 });
 console.log("Link created:", linkId);
+
+// Prefer createPaymentLink when you need QR / shareable URL
+const { linkId: payLinkId, shareableUrl, qrCodeData } = await client.createPaymentLink({
+  merchant: "G...",
+  amount: 5_000_000n,
+  usdcToken: "C...",
+  baseUrl: "https://pay.example.com",
+});
+console.log(shareableUrl, qrCodeData);
 
 // Open-amount link (payer sets the amount)
 const openLinkId = await client.createLink({

--- a/sdk/src/contracts/fluxapay/src/index.ts
+++ b/sdk/src/contracts/fluxapay/src/index.ts
@@ -64,6 +64,11 @@ export interface CreatePaymentArgs {
   token_address: Option<string>;
   client_token: Option<string>;
   metadata_hash: Option<Buffer>;
+  /**
+   * Optional payment metadata.
+   * Limits: ≤20 keys; each key ≤64 chars; each value ≤256 chars.
+   * On-chain errors: MetadataTooLarge (#49), MetadataValueTooLong (#47).
+   */
   metadata: Option<Record<string, string>>;
   fee_waiver_code: Option<string>;
 }

--- a/sdk/src/contracts/fx-oracle.ts
+++ b/sdk/src/contracts/fx-oracle.ts
@@ -13,6 +13,7 @@ export const FX_ORACLE_ERROR_MAP: Record<number, string> = {
   1: "RateNotFound",
   2: "RateStale",
   3: "Unauthorized",
+  4: "BatchTooLarge",
 };
 
 export class FxOracleError extends Error {
@@ -200,6 +201,33 @@ export class FxOracleClient {
       this.getContract().set_staleness_threshold({
         admin,
         threshold,
+      }),
+    );
+  }
+
+  /**
+   * Permissionless probe: returns true when the rate is stale (emits RATE/STALE_ALERT).
+   * @param pair - Currency pair symbol
+   */
+  async checkRateStaleness(pair: string): Promise<boolean> {
+    return withFxOracleContractError(() =>
+      this.getContract().check_rate_staleness({ pair }),
+    );
+  }
+
+  /**
+   * Atomically update up to 20 currency pairs. Requires the ORACLE role.
+   * @param operator - Address with the ORACLE role
+   * @param rates - Array of `[pair, rate, decimals]` tuples
+   */
+  async setRatesBatch(
+    operator: string,
+    rates: Array<[string, bigint, number]>,
+  ): Promise<number> {
+    return withFxOracleContractError(() =>
+      this.getContract().set_rates_batch({
+        operator,
+        rates,
       }),
     );
   }

--- a/sdk/src/contracts/payment-link-manager.ts
+++ b/sdk/src/contracts/payment-link-manager.ts
@@ -21,8 +21,14 @@ export interface PaymentLink {
   active: boolean;
   /** USDC token contract address */
   usdc_token: string;
-  /** Arbitrary key/value metadata attached to the link */
+  /**
+   * Arbitrary key/value metadata attached to the link.
+   *
+   * Limits (enforced on-chain): ≤20 keys, key ≤64 chars, value ≤256 chars.
+   */
   metadata?: Record<string, string>;
+  /** Canonical shareable checkout URL (`{base_url}/pay/{link_id}`), if configured */
+  shareable_url?: string;
 }
 
 /**
@@ -43,8 +49,6 @@ export interface LinkAnalytics {
   conversion_rate: number;
 }
 
-
-
 /**
  * Parameters for creating a new payment link.
  */
@@ -55,8 +59,34 @@ export interface CreateLinkParams {
   amount?: bigint;
   /** USDC token contract address */
   usdcToken: string;
-  /** Arbitrary metadata (e.g. product info, order reference) */
+  /**
+   * Arbitrary metadata (e.g. product info, order reference).
+   *
+   * Limits (enforced on-chain): ≤20 keys, key ≤64 chars, value ≤256 chars.
+   */
   metadata?: Record<string, string>;
+  /**
+   * Optional checkout base URL. When provided (or when admin has set a default
+   * via `set_payment_base_url`), the link stores `{baseUrl}/pay/{linkId}` as
+   * `shareable_url`.
+   */
+  baseUrl?: string;
+  /** Optional link ID; when omitted the contract/caller supplies one */
+  linkId?: string;
+  currency?: string;
+  description?: string;
+}
+
+/** Result of `createPaymentLink`, including QR-ready payload. */
+export interface CreatePaymentLinkResult {
+  linkId: string;
+  /** Canonical shareable URL when a base URL was available; otherwise null */
+  shareableUrl: string | null;
+  /**
+   * String suitable for QR code generation (the shareable URL when present,
+   * otherwise the raw link ID).
+   */
+  qrCodeData: string;
 }
 
 /**
@@ -115,10 +145,57 @@ export class PaymentLinkManagerClient {
     return withMappedContractError(() =>
       this.getContract().create_link({
         merchant: params.merchant,
+        link_id: params.linkId,
         amount: params.amount,
+        currency: params.currency ?? "USDC",
+        description: params.description ?? "",
+        expires_at: undefined,
+        max_uses: undefined,
+        direct_transfer: false,
         usdc_token: params.usdcToken,
         metadata: params.metadata,
+        base_url: params.baseUrl,
       }),
+    );
+  }
+
+  /**
+   * Create a payment link and return shareable URL + QR payload.
+   *
+   * @param params - Link creation parameters (include `baseUrl` for a shareable URL)
+   * @returns linkId, shareableUrl, and qrCodeData for invoice/QR embedding
+   */
+  async createPaymentLink(params: CreateLinkParams): Promise<CreatePaymentLinkResult> {
+    const linkId = await this.createLink(params);
+    let shareableUrl: string | null = null;
+    try {
+      shareableUrl = (await this.getLinkUrl(linkId)) ?? null;
+    } catch {
+      shareableUrl = params.baseUrl ? `${params.baseUrl.replace(/\/$/, "")}/pay/${linkId}` : null;
+    }
+    return {
+      linkId,
+      shareableUrl,
+      qrCodeData: shareableUrl ?? linkId,
+    };
+  }
+
+  /**
+   * Query the on-chain shareable URL for a link.
+   */
+  async getLinkUrl(linkId: string): Promise<string | null> {
+    return withMappedContractError(async () => {
+      const url = await this.getContract().get_link_url({ link_id: linkId });
+      return url ?? null;
+    });
+  }
+
+  /**
+   * Admin: set the default payment base URL used when create_link omits base_url.
+   */
+  async setPaymentBaseUrl(admin: string, url: string): Promise<void> {
+    return withMappedContractError(() =>
+      this.getContract().set_payment_base_url({ admin, url }),
     );
   }
 
@@ -217,6 +294,3 @@ export class PaymentLinkManagerClient {
     );
   }
 }
-
-
-

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -31,6 +31,7 @@ import {
   type PaymentLink,
   type LinkAnalytics,
   type CreateLinkParams,
+  type CreatePaymentLinkResult,
 } from "./contracts/payment-link-manager.js";
 
 
@@ -59,6 +60,17 @@ export interface CreatePaymentParams {
   memoType?: string;
   tokenAddress?: string;
   clientToken?: string;
+  /**
+   * Optional payment metadata map.
+   *
+   * Limits (enforced on-chain):
+   * - At most 20 keys
+   * - Each key ≤ 64 characters
+   * - Each value ≤ 256 characters
+   *
+   * Violations return `MetadataTooLarge` (#49) or `MetadataValueTooLong` (#47).
+   */
+  metadata?: Record<string, string>;
   /**
    * Optional per-payment fee-waiver code. If the code is valid at
    * settlement time (exists, not expired, still has remaining uses), the
@@ -121,6 +133,8 @@ export const FLUXAPAY_CONTRACT_ERROR_MAP: Record<number, string> = {
   37: "ArbitrationVotingThresholdNotMet",
   38: "FeeProposalNotReady",
   39: "NoFeeProposal",
+  47: "MetadataValueTooLong",
+  49: "MetadataTooLarge",
   404: "PaymentNotFound",
   405: "RefundNotFound",
   406: "InvalidAmount",
@@ -211,7 +225,7 @@ function toCreatePaymentArgs(params: CreatePaymentParams): CreatePaymentArgs {
     token_address: params.tokenAddress,
     client_token: params.clientToken,
     metadata_hash: undefined,
-    metadata: undefined,
+    metadata: params.metadata,
     fee_waiver_code: params.feeWaiverCode,
   };
 }
@@ -631,11 +645,29 @@ export class FluxapayClient {
    * @param params.merchant - The merchant's Stellar address
    * @param params.amount - Optional fixed amount in stroops
    * @param params.usdcToken - USDC token contract address
-   * @param params.metadata - Optional key/value metadata
+   * @param params.metadata - Optional key/value metadata (≤20 keys, key≤64, value≤256)
+   * @param params.baseUrl - Optional checkout base URL for shareable_url
    * @returns A promise resolving to the new link ID
    */
   async createLink(params: CreateLinkParams): Promise<string> {
     return this.getPaymentLinkManager().createLink(params);
+  }
+
+  /**
+   * Create a payment link and return shareable URL + QR code payload.
+   *
+   * @returns `{ linkId, shareableUrl, qrCodeData }` where `qrCodeData` is the
+   * shareable URL (or link ID fallback) suitable for QR generation.
+   */
+  async createPaymentLink(params: CreateLinkParams): Promise<CreatePaymentLinkResult> {
+    return this.getPaymentLinkManager().createPaymentLink(params);
+  }
+
+  /**
+   * Query the on-chain shareable URL for a payment link.
+   */
+  async getLinkUrl(linkId: string): Promise<string | null> {
+    return this.getPaymentLinkManager().getLinkUrl(linkId);
   }
 
   /**
@@ -758,6 +790,7 @@ export {
   type PaymentLink,
   type LinkAnalytics,
   type CreateLinkParams,
+  type CreatePaymentLinkResult,
 } from "./contracts/payment-link-manager.js";
 
 


### PR DESCRIPTION
closes #467 
closes #473 
closes #475 
closes #479

### PR description

## Summary
Implements four contract/SDK improvements on one branch:

1. **Metadata size validation** — enforce ≤20 keys, key ≤64, value ≤256 in `create_payment` / `create_payments_batch` / `create_link` via shared `utils::validate_metadata`; document limits in README + SDK JSDoc.
2. **Cancellable subscriptions with proration** — `cancel_subscription(payer, id, refund_remaining)` + admin `set_allow_prorated_refunds`; mid-period cancels can create a pending refund and emit `REFUND/AUTO_CREATED`.
3. **Payment link shareable URL** — `shareable_url` on `PaymentLink`, optional `base_url` / admin `set_payment_base_url`, `get_link_url`, SDK `createPaymentLink` → `{ linkId, shareableUrl, qrCodeData }`.
4. **FX oracle bulk update + staleness alert** — `check_rate_staleness` (emits `RATE/STALE_ALERT`) and `set_rates_batch` (max 20, ORACLE role, emits `RATE/BATCH_UPDATED`).

## Test plan
- [ ] `cargo test -p fluxapay payment_metadata_test`
- [ ] `cargo test -p fluxapay payment_link_test::test_create_link_with_base_url` / `without_base_url` / `set_payment_base_url`
- [ ] `cargo test -p fluxapay subscription_test::test_cancel_subscription_mid_period`
- [ ] `cargo test -p fluxapay fx_oracle_test::test_check_rate_staleness` / `test_set_rates_batch`
- [ ] Confirm SDK `createPaymentLink` returns `qrCodeData` when `baseUrl` is set

## Notes
Full `cargo test -p fluxapay --lib` still fails on **preexisting** breakage elsewhere (`ReconciliationReport`, `fee_waiver_code` test literals, Soroban 26.1 `ContractEvents` API in older tests, etc.). Task logic and new unit tests are in place on this branch.