### PR TITLE
feat(sdk): offline subscription payloads, gas estimator wiring, and stream methods

### DIFF
--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/deploy-testnet.sh
 #
-# Deploys all five FluxaPay contracts to Stellar testnet (or the network set
+# Deploys all six FluxaPay contracts to Stellar testnet (or the network set
 # in STELLAR_NETWORK) in dependency order, initialises each contract with the
 # deployer as admin, and writes the resulting contract IDs to .env.testnet.
 #
@@ -16,6 +16,7 @@
 #   3. PaymentProcessor
 #   4. RefundManager
 #   5. PaymentLinkManager
+#   6. GasEstimator
 #
 # Required environment variables:
 #   STELLAR_SECRET_KEY  — deployer secret key (starts with S)
@@ -128,19 +129,22 @@ echo "=== Deploying Contracts ==="
 echo ""
 
 # 1. FXOracle
-FX_ORACLE_CONTRACT_ID="$(deploy_contract "1/5" "FXOracle" | tail -1)"
+FX_ORACLE_CONTRACT_ID="$(deploy_contract "1/6" "FXOracle" | tail -1)"
 
 # 2. MerchantRegistry
-MERCHANT_REGISTRY_CONTRACT_ID="$(deploy_contract "2/5" "MerchantRegistry" | tail -1)"
+MERCHANT_REGISTRY_CONTRACT_ID="$(deploy_contract "2/6" "MerchantRegistry" | tail -1)"
 
 # 3. PaymentProcessor
-PAYMENT_PROCESSOR_CONTRACT_ID="$(deploy_contract "3/5" "PaymentProcessor" | tail -1)"
+PAYMENT_PROCESSOR_CONTRACT_ID="$(deploy_contract "3/6" "PaymentProcessor" | tail -1)"
 
 # 4. RefundManager
-REFUND_MANAGER_CONTRACT_ID="$(deploy_contract "4/5" "RefundManager" | tail -1)"
+REFUND_MANAGER_CONTRACT_ID="$(deploy_contract "4/6" "RefundManager" | tail -1)"
 
 # 5. PaymentLinkManager
-PAYMENT_LINK_MANAGER_CONTRACT_ID="$(deploy_contract "5/5" "PaymentLinkManager" | tail -1)"
+PAYMENT_LINK_MANAGER_CONTRACT_ID="$(deploy_contract "5/6" "PaymentLinkManager" | tail -1)"
+
+# 6. GasEstimator
+GAS_ESTIMATOR_CONTRACT_ID="$(deploy_contract "6/6" "GasEstimator" | tail -1)"
 
 echo ""
 echo "=== Initialising Contracts ==="
@@ -226,12 +230,14 @@ MERCHANT_REGISTRY_CONTRACT_ID=${MERCHANT_REGISTRY_CONTRACT_ID}
 PAYMENT_PROCESSOR_CONTRACT_ID=${PAYMENT_PROCESSOR_CONTRACT_ID}
 REFUND_MANAGER_CONTRACT_ID=${REFUND_MANAGER_CONTRACT_ID}
 PAYMENT_LINK_MANAGER_CONTRACT_ID=${PAYMENT_LINK_MANAGER_CONTRACT_ID}
+GAS_ESTIMATOR_CONTRACT_ID=${GAS_ESTIMATOR_CONTRACT_ID}
 
 # Aliases kept for backward compatibility with existing tooling
 PAYMENT_PROCESSOR_ID=${PAYMENT_PROCESSOR_CONTRACT_ID}
 REFUND_MANAGER_ID=${REFUND_MANAGER_CONTRACT_ID}
 MERCHANT_REGISTRY_ID=${MERCHANT_REGISTRY_CONTRACT_ID}
 FX_ORACLE_ID=${FX_ORACLE_CONTRACT_ID}
+GAS_ESTIMATOR_ID=${GAS_ESTIMATOR_CONTRACT_ID}
 EOF
 
 echo "   Written."
@@ -341,6 +347,7 @@ echo "  MerchantRegistry       : $MERCHANT_REGISTRY_CONTRACT_ID"
 echo "  PaymentProcessor       : $PAYMENT_PROCESSOR_CONTRACT_ID"
 echo "  RefundManager          : $REFUND_MANAGER_CONTRACT_ID"
 echo "  PaymentLinkManager     : $PAYMENT_LINK_MANAGER_CONTRACT_ID"
+echo "  GasEstimator           : $GAS_ESTIMATOR_CONTRACT_ID"
 echo ""
 echo "  Contract IDs written to: $ENV_OUT"
 echo ""

--- a/scripts/deploy_testnet.sh
+++ b/scripts/deploy_testnet.sh
@@ -38,17 +38,20 @@ deploy() {
 }
 
 # ── Deploy each contract ──────────────────────────────────────────────────────
-PAYMENT_PROCESSOR_ID=$(deploy "1/4 PaymentProcessor" "$WASM_DIR/fluxapay.wasm")
+PAYMENT_PROCESSOR_ID=$(deploy "1/5 PaymentProcessor" "$WASM_DIR/fluxapay.wasm")
 echo "$PAYMENT_PROCESSOR_ID"
 
-REFUND_MANAGER_ID=$(deploy "2/4 RefundManager" "$WASM_DIR/fluxapay.wasm")
+REFUND_MANAGER_ID=$(deploy "2/5 RefundManager" "$WASM_DIR/fluxapay.wasm")
 echo "$REFUND_MANAGER_ID"
 
-MERCHANT_REGISTRY_ID=$(deploy "3/4 MerchantRegistry" "$WASM_DIR/fluxapay.wasm")
+MERCHANT_REGISTRY_ID=$(deploy "3/5 MerchantRegistry" "$WASM_DIR/fluxapay.wasm")
 echo "$MERCHANT_REGISTRY_ID"
 
-FX_ORACLE_ID=$(deploy "4/4 FXOracle" "$WASM_DIR/fluxapay.wasm")
+FX_ORACLE_ID=$(deploy "4/5 FXOracle" "$WASM_DIR/fluxapay.wasm")
 echo "$FX_ORACLE_ID"
+
+GAS_ESTIMATOR_ID=$(deploy "5/5 GasEstimator" "$WASM_DIR/fluxapay.wasm")
+echo "$GAS_ESTIMATOR_ID"
 
 # ── Write .env.testnet ────────────────────────────────────────────────────────
 cat > "$ENV_OUT" <<EOF
@@ -58,6 +61,7 @@ PAYMENT_PROCESSOR_ID=${PAYMENT_PROCESSOR_ID}
 REFUND_MANAGER_ID=${REFUND_MANAGER_ID}
 MERCHANT_REGISTRY_ID=${MERCHANT_REGISTRY_ID}
 FX_ORACLE_ID=${FX_ORACLE_ID}
+GAS_ESTIMATOR_ID=${GAS_ESTIMATOR_ID}
 EOF
 
 echo "Contract IDs written to .env.testnet"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -393,6 +393,81 @@ await linkClient.deactivateLink("G_merchant...", linkId);
 const active = await linkClient.verifyBatch([linkId]);
 ```
 
+## Payment Streams
+
+`FluxapayClient` exposes wrappers for continuous payment streaming (`PaymentProcessor.create_stream` and related on-chain methods).
+
+```typescript
+const stream = await client.createStream({
+  sender: "G_SENDER...",
+  receiver: "G_RECEIVER...",
+  token: "C_USDC_TOKEN...",
+  ratePerSecond: 100n,
+  deposit: 1_000_000n,
+  streamId: "stream_001",
+});
+
+await client.topUpStream("G_SENDER...", "stream_001", 500_000n);
+await client.pauseStream("G_SENDER...", "stream_001");
+await client.resumeStream("G_SENDER...", "stream_001");
+
+// Withdraw everything accrued so far to the receiver
+await client.withdrawStream("G_RECEIVER...", "stream_001");
+
+const details = await client.getStream("stream_001");
+const senderStreams = await client.getSenderStreams("G_SENDER...");
+
+await client.cancelStream("G_SENDER...", "stream_001");
+```
+
+## Gas Estimation
+
+`GasEstimatorClient` queries the on-chain `GasEstimator` contract for predicted Soroban resource costs (instructions, ledger reads/writes, events, and resource fee in stroops) before submitting a transaction.
+
+```typescript
+import { GasEstimatorClient } from "@fluxapay/sdk";
+
+const gasEstimator = new GasEstimatorClient({
+  network: "testnet",
+  gasEstimatorContractId: "C...", // GasEstimator contract ID
+});
+
+const estimate = await gasEstimator.estimate("CreatePayment");
+console.log(estimate.resourceFeeStroops);
+
+const allEstimates = await gasEstimator.estimateAll();
+```
+
+## Offline / Hardware Wallet Signing
+
+`FluxapayClient.offlineSigner()` returns a `FluxapayOfflineSigner` that builds unsigned transaction payloads (XDR + JSON snapshot + required signers) for offline or hardware-wallet signing workflows, without submitting them.
+
+Supported operations: `create_payment`, `verify_payment`, `create_refund`, and (for backend billing services) `charge_subscription` and `pull_payment`.
+
+```typescript
+const signer = client.offlineSigner();
+
+// Pre-build a subscription tick for batch submission or hardware-wallet signing.
+const tickPayload = await signer.buildSubscriptionTick({
+  operator: "G_OPERATOR...",
+  subscriptionId: "sub_123",
+  token: "C_USDC_TOKEN...",
+});
+
+// Pre-build a pre-authorized pull payment.
+const pullPayload = await signer.buildPullAuthorization({
+  merchant: "G_MERCHANT...",
+  customer: "G_CUSTOMER...",
+  amount: 5_000_000n,
+});
+
+// Each payload contains `unsignedXdr`, `hash`, `json`, and `requiredAuthSigners`.
+// Sign `unsignedXdr` offline, then restore + submit:
+const restored = signer.restore(tickPayload);
+```
+
+You can also use the standalone builder functions directly: `buildSubscriptionTickPayload`, `buildPullAuthorizationPayload`, `buildCreatePaymentPayload`, `buildVerifyPaymentPayload`, `buildCreateRefundPayload`.
+
 ## License
 
 MIT

--- a/sdk/src/contracts/gas-estimator.ts
+++ b/sdk/src/contracts/gas-estimator.ts
@@ -1,0 +1,121 @@
+import { NetworkProfileSwitcher, NetworkEnvironment } from "../network-profiles.js";
+
+export interface GasEstimatorConfig {
+  network: NetworkEnvironment;
+  rpcUrl?: string;
+  gasEstimatorContractId: string;
+}
+
+/** Mirrors the on-chain `Operation` enum in `gas_estimator.rs`. */
+export type GasOperation =
+  | "CreatePayment"
+  | "VerifyPayment"
+  | "CancelPayment"
+  | "ExpirePayment"
+  | "SettlePayment"
+  | "CreateRefund"
+  | "ProcessRefund"
+  | "RejectRefund"
+  | "CancelRefund"
+  | "CreateDispute"
+  | "ResolveDispute"
+  | "RejectDispute"
+  | "SwapAndPay"
+  | "CreateStream"
+  | "WithdrawStream"
+  | "CancelStream";
+
+/** Mirrors the on-chain `CostEstimate` struct returned by `GasEstimator`. */
+export interface GasEstimate {
+  operation: GasOperation;
+  instructions: bigint;
+  ledgerReads: number;
+  ledgerWrites: number;
+  events: number;
+  resourceFeeStroops: bigint;
+}
+
+function fromContractEstimate(raw: {
+  operation: GasOperation;
+  instructions: bigint;
+  ledger_reads: number;
+  ledger_writes: number;
+  events: number;
+  resource_fee_stroops: bigint;
+}): GasEstimate {
+  return {
+    operation: raw.operation,
+    instructions: raw.instructions,
+    ledgerReads: raw.ledger_reads,
+    ledgerWrites: raw.ledger_writes,
+    events: raw.events,
+    resourceFeeStroops: raw.resource_fee_stroops,
+  };
+}
+
+/**
+ * GasEstimatorClient provides a high-level interface for querying on-chain
+ * Soroban resource cost estimates from the `GasEstimator` contract before
+ * submitting a transaction.
+ */
+export class GasEstimatorClient {
+  private contract: any;
+  public networkSwitcher: NetworkProfileSwitcher;
+  private gasEstimatorContractId: string;
+  private rpcUrl: string;
+  private networkPassphrase: string;
+
+  constructor(config: GasEstimatorConfig) {
+    this.networkSwitcher = new NetworkProfileSwitcher(config.network);
+    const profile = this.networkSwitcher.getProfile();
+    this.rpcUrl = config.rpcUrl || profile.rpcUrl;
+    this.networkPassphrase = profile.networkPassphrase;
+    this.gasEstimatorContractId = config.gasEstimatorContractId;
+  }
+
+  private getContract(): any {
+    if (!this.contract) {
+      const { Client } = require("@stellar/stellar-sdk/contract");
+      this.contract = new Client({
+        networkPassphrase: this.networkPassphrase,
+        rpcUrl: this.rpcUrl,
+        contractId: this.gasEstimatorContractId,
+      });
+    }
+    return this.contract;
+  }
+
+  /**
+   * Switch the client to a different network environment.
+   * @param environment - The target network environment (e.g., 'testnet', 'mainnet')
+   * @param gasEstimatorContractId - Optional GasEstimator contract ID for the new network
+   */
+  public switchNetwork(environment: NetworkEnvironment, gasEstimatorContractId?: string): void {
+    this.networkSwitcher.switchEnvironment(environment);
+    const profile = this.networkSwitcher.getProfile();
+    this.rpcUrl = profile.rpcUrl;
+    this.networkPassphrase = profile.networkPassphrase;
+    if (gasEstimatorContractId) {
+      this.gasEstimatorContractId = gasEstimatorContractId;
+    }
+    this.contract = undefined;
+  }
+
+  /** Estimate the resource cost of a single operation. */
+  async estimate(operation: GasOperation): Promise<GasEstimate> {
+    const raw = await this.getContract().estimate({ op: operation });
+    return fromContractEstimate(raw);
+  }
+
+  /** Estimate the resource cost of every supported operation. */
+  async estimateAll(): Promise<GasEstimate[]> {
+    const raw: Array<Parameters<typeof fromContractEstimate>[0]> =
+      await this.getContract().estimate_all();
+    return raw.map(fromContractEstimate);
+  }
+
+  /** Fetch the on-chain Symbol name for an operation (useful for display). */
+  async operationName(operation: GasOperation): Promise<string> {
+    return this.getContract().operation_name({ op: operation });
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -15,10 +15,13 @@ import { Networks } from "@stellar/stellar-sdk";
 import {
   FluxapayOfflineSigner,
   OfflineTransactionPayload,
+  SubscriptionBillingClient,
   buildOfflinePayload,
   buildCreatePaymentPayload,
   buildVerifyPaymentPayload,
   buildCreateRefundPayload,
+  buildSubscriptionTickPayload,
+  buildPullAuthorizationPayload,
   prepareForOfflineSigning,
   restoreFromOfflinePayload,
 } from "./offline-signer.js";
@@ -80,6 +83,85 @@ export interface CreatePaymentParams {
    */
   feeWaiverCode?: string;
 }
+
+/** Mirrors the on-chain `StreamStatus` enum in `stream.rs`. */
+export type StreamStatus = "Active" | "Cancelled" | "Exhausted" | "Paused";
+
+/** Mirrors the on-chain `StreamError` enum in `stream.rs`. */
+export enum StreamError {
+  StreamNotFound = 1,
+  Unauthorized = 2,
+  RateNotDecreased = 3,
+  InvalidRate = 4,
+  StreamAlreadyExists = 5,
+  InvalidDeposit = 6,
+  StreamNotActive = 7,
+  DestinationNotSet = 8,
+  ContractPaused = 9,
+  MilestoneNotApproved = 10,
+  WithdrawalInProgress = 11,
+  RateBelowMinimum = 12,
+  StreamNotPaused = 13,
+  InvalidReceiver = 14,
+}
+
+/** Mirrors the on-chain `PaymentStream` struct in `stream.rs`. */
+export interface PaymentStream {
+  streamId: string;
+  sender: string;
+  receiver: string;
+  destination: string | null;
+  token: string;
+  ratePerSecond: bigint;
+  minRatePerSecond: bigint;
+  remainingDeposit: bigint;
+  lastCheckpointAt: bigint;
+  accruedAtCheckpoint: bigint;
+  status: StreamStatus;
+  milestonesApproved: boolean;
+}
+
+export interface CreateStreamParams {
+  sender: string;
+  receiver: string;
+  token: string;
+  ratePerSecond: bigint;
+  deposit: bigint;
+  streamId: string;
+}
+
+function fromContractStream(raw: {
+  stream_id: string;
+  sender: string;
+  receiver: string;
+  destination?: string | null;
+  token: string;
+  rate_per_second: bigint;
+  min_rate_per_second: bigint;
+  remaining_deposit: bigint;
+  last_checkpoint_at: bigint;
+  accrued_at_checkpoint: bigint;
+  status: StreamStatus;
+  milestones_approved: boolean;
+}): PaymentStream {
+  return {
+    streamId: raw.stream_id,
+    sender: raw.sender,
+    receiver: raw.receiver,
+    destination: raw.destination ?? null,
+    token: raw.token,
+    ratePerSecond: raw.rate_per_second,
+    minRatePerSecond: raw.min_rate_per_second,
+    remainingDeposit: raw.remaining_deposit,
+    lastCheckpointAt: raw.last_checkpoint_at,
+    accruedAtCheckpoint: raw.accrued_at_checkpoint,
+    status: raw.status,
+    milestonesApproved: raw.milestones_approved,
+  };
+}
+
+/** Max i128 value, used as a sentinel "withdraw everything accrued" amount. */
+const I128_MAX = (1n << 127n) - 1n;
 
 export interface RegisterMerchantParams {
   merchantId: string;
@@ -822,6 +904,109 @@ export class FluxapayClient {
     return this.getPaymentLinkManager().getLinkAnalytics(linkId);
   }
 
+  /**
+   * Create a new payment stream. Tokens are pulled from `params.sender` into
+   * the contract and streamed to `params.receiver` at `ratePerSecond`.
+   * Maps to `PaymentProcessor.create_stream` on-chain.
+   */
+  async createStream(params: CreateStreamParams): Promise<PaymentStream> {
+    const raw = await withMappedContractError(() =>
+      (this.contract as any).create_stream({
+        sender: params.sender,
+        receiver: params.receiver,
+        token: params.token,
+        rate_per_second: params.ratePerSecond,
+        deposit: params.deposit,
+        stream_id: params.streamId,
+      }),
+    );
+    return fromContractStream(raw);
+  }
+
+  /**
+   * Withdraw accrued funds from a stream to `recipient`.
+   * Maps to `PaymentProcessor.batch_withdraw_to` on-chain with a single entry.
+   * @param recipient - Must be the stream's receiver; must sign.
+   * @param streamId - The stream to withdraw from.
+   * @param amount - Optional amount cap; defaults to withdrawing everything accrued.
+   */
+  async withdrawStream(recipient: string, streamId: string, amount?: bigint): Promise<void> {
+    return withMappedContractError(() =>
+      (this.contract as any).batch_withdraw_to({
+        recipient,
+        withdrawals: [
+          { stream_id: streamId, destination: recipient, amount: amount ?? I128_MAX },
+        ],
+      }),
+    );
+  }
+
+  /**
+   * Cancel an active stream and refund any un-accrued deposit to the sender.
+   * Maps to `PaymentProcessor.cancel_stream` on-chain.
+   */
+  async cancelStream(sender: string, streamId: string): Promise<void> {
+    return withMappedContractError(() =>
+      (this.contract as any).cancel_stream({ sender, stream_id: streamId }),
+    );
+  }
+
+  /**
+   * Pause an active stream, freezing accrual until resumed.
+   * Maps to `PaymentProcessor.pause_stream` on-chain.
+   */
+  async pauseStream(sender: string, streamId: string): Promise<void> {
+    return withMappedContractError(() =>
+      (this.contract as any).pause_stream({ sender, stream_id: streamId }),
+    );
+  }
+
+  /**
+   * Resume a paused stream, restarting accrual from the current timestamp.
+   * Maps to `PaymentProcessor.resume_stream` on-chain.
+   */
+  async resumeStream(sender: string, streamId: string): Promise<void> {
+    return withMappedContractError(() =>
+      (this.contract as any).resume_stream({ sender, stream_id: streamId }),
+    );
+  }
+
+  /**
+   * Top up an existing stream's deposit.
+   * Maps to `PaymentProcessor.top_up_stream` on-chain.
+   */
+  async topUpStream(sender: string, streamId: string, amount: bigint): Promise<void> {
+    return withMappedContractError(() =>
+      (this.contract as any).top_up_stream({ caller: sender, stream_id: streamId, amount }),
+    );
+  }
+
+  /**
+   * Get stream details by ID.
+   * Maps to `PaymentProcessor.get_stream` on-chain.
+   */
+  async getStream(streamId: string): Promise<PaymentStream> {
+    const raw = await withMappedContractError(() =>
+      (this.contract as any).get_stream({ stream_id: streamId }),
+    );
+    return fromContractStream(raw);
+  }
+
+  /**
+   * Query streams created by `sender`, paginated (max 100 per page).
+   * Maps to `PaymentProcessor.get_sender_streams` on-chain.
+   */
+  async getSenderStreams(
+    sender: string,
+    page = 0,
+    pageSize = 100,
+  ): Promise<PaymentStream[]> {
+    const raw: unknown[] = await withMappedContractError(() =>
+      (this.contract as any).get_sender_streams({ sender, page, page_size: pageSize }),
+    );
+    return raw.map((s) => fromContractStream(s as Parameters<typeof fromContractStream>[0]));
+  }
+
   /** Offline/hardware wallet payload builder utilities. */
 
 
@@ -849,16 +1034,23 @@ export {
   CreatePaymentArgs,
   FluxapayOfflineSigner,
   OfflineTransactionPayload,
+  SubscriptionBillingClient,
   buildOfflinePayload,
   buildCreatePaymentPayload,
   buildVerifyPaymentPayload,
   buildCreateRefundPayload,
+  buildSubscriptionTickPayload,
+  buildPullAuthorizationPayload,
   prepareForOfflineSigning,
   restoreFromOfflinePayload,
   NetworkProfileSwitcher,
   NetworkEnvironment,
   NetworkProfiles,
   NetworkProfile,
+  PaymentStream,
+  StreamStatus,
+  StreamError,
+  CreateStreamParams,
 };
 
 export { RefundManagerClient, type RefundManagerConfig } from "./contracts/refund-manager.js";
@@ -879,6 +1071,12 @@ export {
   type CreatePaymentLinkResult,
 } from "./contracts/payment-link-manager.js";
 export { SEP10Authenticator, type SEP10ChallengeResponse, type SEP10AuthenticatedResponse } from "./sep10.js";
+export {
+  GasEstimatorClient,
+  type GasEstimatorConfig,
+  type GasEstimate,
+  type GasOperation,
+} from "./contracts/gas-estimator.js";
 
 
 

--- a/sdk/src/offline-signer.ts
+++ b/sdk/src/offline-signer.ts
@@ -23,7 +23,28 @@ export type OfflineCapableClient = ContractClient & {
   fromJSON: Record<string, (json: string) => AssembledTransaction<unknown>>;
 };
 
-/** Ensure simulation completed so payload fields are populated. */
+/** Extended client surface covering subscription/pre-auth billing operations
+ * not yet present in the generated `ContractClient` bindings. */
+export type SubscriptionBillingClient = OfflineCapableClient & {
+  charge_subscription(args: {
+    operator: string;
+    subscription_id: string;
+    token: string;
+  }): Promise<AssembledTransaction<unknown>>;
+  pull_payment(args: {
+    merchant: string;
+    customer: string;
+    amount: bigint;
+  }): Promise<AssembledTransaction<unknown>>;
+};
+
+/**
+ * Ensure simulation completed so payload fields are populated.
+ *
+ * Operation-agnostic: works for any `AssembledTransaction`, including the
+ * `charge_subscription` and `pull_payment` operations used by
+ * `buildSubscriptionTickPayload` / `buildPullAuthorizationPayload`.
+ */
 export async function prepareForOfflineSigning<T>(
   tx: AssembledTransaction<T>,
 ): Promise<AssembledTransaction<T>> {
@@ -98,6 +119,36 @@ export async function buildCreateRefundPayload(
   return buildOfflinePayload("create_refund", contractId, networkPassphrase, tx);
 }
 
+/** Raw payload builder for `charge_subscription` (subscription tick) invocations. */
+export async function buildSubscriptionTickPayload(
+  client: SubscriptionBillingClient,
+  contractId: string,
+  networkPassphrase: string,
+  params: { operator: string; subscriptionId: string; token: string },
+): Promise<OfflineTransactionPayload> {
+  const tx = await client.charge_subscription({
+    operator: params.operator,
+    subscription_id: params.subscriptionId,
+    token: params.token,
+  });
+  return buildOfflinePayload("charge_subscription", contractId, networkPassphrase, tx);
+}
+
+/** Raw payload builder for `pull_payment` (pre-authorized pull) invocations. */
+export async function buildPullAuthorizationPayload(
+  client: SubscriptionBillingClient,
+  contractId: string,
+  networkPassphrase: string,
+  params: { merchant: string; customer: string; amount: bigint },
+): Promise<OfflineTransactionPayload> {
+  const tx = await client.pull_payment({
+    merchant: params.merchant,
+    customer: params.customer,
+    amount: params.amount,
+  });
+  return buildOfflinePayload("pull_payment", contractId, networkPassphrase, tx);
+}
+
 /**
  * High-level helper exposing common raw payload builders for hardware wallets.
  */
@@ -138,6 +189,32 @@ export class FluxapayOfflineSigner {
       this.contractId,
       this.networkPassphrase,
       args,
+    );
+  }
+
+  buildSubscriptionTick(params: {
+    operator: string;
+    subscriptionId: string;
+    token: string;
+  }): Promise<OfflineTransactionPayload> {
+    return buildSubscriptionTickPayload(
+      this.client as SubscriptionBillingClient,
+      this.contractId,
+      this.networkPassphrase,
+      params,
+    );
+  }
+
+  buildPullAuthorization(params: {
+    merchant: string;
+    customer: string;
+    amount: bigint;
+  }): Promise<OfflineTransactionPayload> {
+    return buildPullAuthorizationPayload(
+      this.client as SubscriptionBillingClient,
+      this.contractId,
+      this.networkPassphrase,
+      params,
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #460, 
Closes #456, 
Closes #457

### #460 — offline subscription payloads
- `buildSubscriptionTickPayload` / `buildPullAuthorizationPayload` added to `sdk/src/offline-signer.ts` for `charge_subscription` / `pull_payment`, following the existing `OfflineTransactionPayload` interface and `FluxapayOfflineSigner` class pattern
- Documented in `sdk/README.md`

### #456 — gas estimator contract
- `GasEstimator` already had a live `#[contractimpl]` (`estimate`, `estimate_all`, `operation_name`) — added the missing deployment step to `scripts/deploy_testnet.sh` and `scripts/deploy-testnet.sh`
- Added `GasEstimatorClient` SDK wrapper (`sdk/src/contracts/gas-estimator.ts`), exported from `sdk/src/index.ts`, documented in `sdk/README.md`

### #457 — SDK PaymentStream wrappers
- Added `createStream`, `withdrawStream`, `cancelStream`, `pauseStream`, `resumeStream`, `topUpStream`, `getStream`, `getSenderStreams` to `FluxapayClient`
- Exported `PaymentStream`, `StreamStatus`, `StreamError`, `CreateStreamParams` types
- Documented in `sdk/README.md`