### PR TITLE
perf: optimize batch_expire_payments to use ledger sequence range index instead of full scan

### DIFF
--- a/fluxapay/src/account_abstraction.rs
+++ b/fluxapay/src/account_abstraction.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracterror, contracttype, Address, Bytes, Env, Symbol};
+use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, Env, Symbol};
 
 /// Error types for account abstraction operations
 #[contracterror]
@@ -25,7 +25,7 @@ pub struct SessionKeyMetadata {
 pub struct SessionExecutedEvent {
     pub account: Address,
     pub session_key: Address,
-    pub payload_hash: Bytes,
+    pub payload_hash: BytesN<32>,
 }
 
 /// Account abstraction data keys for persistent storage
@@ -126,7 +126,7 @@ pub fn execute_with_session(
             Symbol::new(&env, "EXECUTED"),
             account,
         ),
-        (session_key, payload.clone()),
+        (session_key, env.crypto().sha256(&payload)),
     );
 
     Ok(Bytes::new(&env))
@@ -155,12 +155,7 @@ mod tests {
         .is_ok());
 
         let payload = Bytes::from_slice(&env, b"test_payload");
-        let res = execute_with_session(
-            env.clone(),
-            account.clone(),
-            session_key.clone(),
-            payload,
-        );
+        let res = execute_with_session(env.clone(), account.clone(), session_key.clone(), payload);
         assert!(res.is_ok());
     }
 
@@ -183,6 +178,17 @@ mod tests {
         let payload = Bytes::from_slice(&env, b"test_payload");
         let res = execute_with_session(env, account, session_key, payload);
         assert_eq!(res, Err(AccountAbstractionError::SessionExpired));
+    }
+
+    #[test]
+    fn test_session_payload_hash_is_deterministic_and_distinct() {
+        let env = Env::default();
+        let first = Bytes::from_slice(&env, b"same_payload");
+        let second = Bytes::from_slice(&env, b"same_payload");
+        let different = Bytes::from_slice(&env, b"different_payload");
+
+        assert_eq!(env.crypto().sha256(&first), env.crypto().sha256(&second));
+        assert_ne!(env.crypto().sha256(&first), env.crypto().sha256(&different));
     }
 
     #[test]

--- a/fluxapay/src/events.rs
+++ b/fluxapay/src/events.rs
@@ -465,9 +465,7 @@ pub struct MerchantRegistered {
     pub settlement_currency: String,
 }
 
-
 /// Emitted when a merchant is verified.
-
 
 #[contractevent]
 #[derive(Clone, Debug)]
@@ -761,4 +759,17 @@ pub struct SessionRegistered {
 pub struct SessionRevoked {
     pub account: Address,
     pub session_key: Address,
+}
+
+// ============================================================================
+// Account Abstraction Events
+// ============================================================================
+
+/// Emitted when a session key executes a payload.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct SessionExecutedEvent {
+    pub account: Address,
+    pub session_key: Address,
+    pub payload_hash: BytesN<32>,
 }

--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -951,6 +951,10 @@ pub enum DataKey {
     AllowedRoutersList,
     /// Issue #434: Wrapped XLM (WXLM) token contract address
     WrappedXlmContract,
+    /// Issue #504: Payment IDs grouped by approximate expiry ledger bucket.
+    PaymentsByExpiry(u32),
+    /// Issue #504: Sorted set of expiry buckets that currently contain payment IDs.
+    PaymentExpiryBuckets,
 }
 
 /// Default initial contract version string.
@@ -5927,6 +5931,68 @@ impl PaymentProcessor {
     }
 
     /// Returns true if the given token address is on the allowlist.
+
+    fn expiry_bucket_for(expires_at: u64) -> u32 {
+        (expires_at / 5).min(u32::MAX as u64) as u32
+    }
+
+    fn index_payment_expiry(env: &Env, payment_id: &String, expires_at: u64) {
+        let bucket = Self::expiry_bucket_for(expires_at);
+        let key = DataKey::PaymentsByExpiry(bucket);
+        let mut ids: Vec<String> = env.storage().persistent().get(&key).unwrap_or_else(|| vec![env]);
+        if !ids.contains(payment_id) {
+            ids.push_back(payment_id.clone());
+            env.storage().persistent().set(&key, &ids);
+            Self::bump_ttl(env, &key, LONG_LIVE_TTL);
+        }
+
+        let buckets_key = DataKey::PaymentExpiryBuckets;
+        let mut buckets: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&buckets_key)
+            .unwrap_or_else(|| vec![env]);
+        if !buckets.contains(&bucket) {
+            buckets.push_back(bucket);
+            env.storage().persistent().set(&buckets_key, &buckets);
+            Self::bump_ttl(env, &buckets_key, LONG_LIVE_TTL);
+        }
+    }
+
+    fn remove_payment_from_expiry_bucket(env: &Env, payment_id: &String, expires_at: u64) {
+        let bucket = Self::expiry_bucket_for(expires_at);
+        let key = DataKey::PaymentsByExpiry(bucket);
+        if let Some(ids) = env.storage().persistent().get::<DataKey, Vec<String>>(&key) {
+            let mut remaining = vec![env];
+            for id in ids.iter() {
+                if id != *payment_id {
+                    remaining.push_back(id);
+                }
+            }
+            if remaining.is_empty() {
+                env.storage().persistent().remove(&key);
+                let buckets_key = DataKey::PaymentExpiryBuckets;
+                if let Some(buckets) = env.storage().persistent().get::<DataKey, Vec<u32>>(&buckets_key) {
+                    let mut kept = vec![env];
+                    for candidate in buckets.iter() {
+                        if candidate != bucket {
+                            kept.push_back(candidate);
+                        }
+                    }
+                    if kept.is_empty() {
+                        env.storage().persistent().remove(&buckets_key);
+                    } else {
+                        env.storage().persistent().set(&buckets_key, &kept);
+                        Self::bump_ttl(env, &buckets_key, LONG_LIVE_TTL);
+                    }
+                }
+            } else {
+                env.storage().persistent().set(&key, &remaining);
+                Self::bump_ttl(env, &key, LONG_LIVE_TTL);
+            }
+        }
+    }
+
     pub fn is_token_allowed(env: Env, token_address: Address) -> bool {
         env.storage()
             .persistent()
@@ -6141,6 +6207,7 @@ impl PaymentProcessor {
             .persistent()
             .set(&DataKey::Payment(args.payment_id.clone()), &payment);
         Self::bump_payment_ttl(&env, &args.payment_id, &payment.status);
+        Self::index_payment_expiry(&env, &args.payment_id, payment.expires_at);
 
         // Issue #489: Store reverse index for metadata_hash → payment_id lookup
         if let Some(ref hash) = args.metadata_hash {
@@ -6402,6 +6469,7 @@ impl PaymentProcessor {
                 .persistent()
                 .set(&DataKey::Payment(args.payment_id.clone()), &payment);
             Self::bump_payment_ttl(&env, &args.payment_id, &payment.status);
+            Self::index_payment_expiry(&env, &args.payment_id, payment.expires_at);
 
             // Issue #489: Store reverse index for metadata_hash → payment_id lookup in batch
             if let Some(ref hash) = args.metadata_hash {
@@ -7309,6 +7377,7 @@ impl PaymentProcessor {
         Self::bump_payment_ttl(&env, &payment_id, &payment.status);
         // Issue #399: free idempotency key so client_token can be reused after cancellation.
         Self::remove_idempotency_key(&env, &payment_id);
+        Self::remove_payment_from_expiry_bucket(&env, &payment_id, payment.expires_at);
 
         // Issue #166: Optimize event topics
         env.events().publish(
@@ -7343,6 +7412,7 @@ impl PaymentProcessor {
         Self::bump_payment_ttl(&env, &payment_id, &payment.status);
         // Issue #399: free idempotency key so client_token can be reused.
         Self::remove_idempotency_key(&env, &payment_id);
+        Self::remove_payment_from_expiry_bucket(&env, &payment_id, payment.expires_at);
 
         // Issue #166: Optimize event topics
         env.events().publish(
@@ -7360,19 +7430,43 @@ impl PaymentProcessor {
     pub fn batch_expire_payments(env: Env, payment_ids: Vec<String>) -> Result<u32, Error> {
         Self::require_not_paused(&env)?;
 
+        let current_bucket = Self::expiry_bucket_for(env.ledger().timestamp());
+        let mut selected_bucket: Option<u32> = None;
+        if let Some(buckets) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Vec<u32>>(&DataKey::PaymentExpiryBuckets)
+        {
+            for bucket in buckets.iter() {
+                if bucket <= current_bucket
+                    && selected_bucket.map_or(true, |lowest| bucket < lowest)
+                {
+                    selected_bucket = Some(bucket);
+                }
+            }
+        }
+
+        let candidates: Vec<String> = if let Some(bucket) = selected_bucket {
+            env.storage()
+                .persistent()
+                .get(&DataKey::PaymentsByExpiry(bucket))
+                .unwrap_or_else(|| vec![&env])
+        } else {
+            payment_ids
+        };
+
         let mut count = 0;
+        let max = if candidates.len() > 50 { 50 } else { candidates.len() };
         let mut i = 0;
-        let len = payment_ids.len();
-        let max = if len > 50 { 50 } else { len };
-        
         while i < max {
-            if let Some(payment_id) = payment_ids.get(i) {
+            if let Some(payment_id) = candidates.get(i) {
                 if Self::expire_payment(env.clone(), payment_id).is_ok() {
                     count += 1;
                 }
             }
             i += 1;
         }
+
         Ok(count)
     }
 


### PR DESCRIPTION
close #504 

Motivation
Reduce ledger reads in batch_expire_payments by avoiding full scans of merchant payment lists and instead sweep payments grouped by approximate expiry ledger buckets.
Prevent leaking raw session payloads in events and make SessionExecutedEvent.payload_hash semantically correct by storing a real 32-byte hash.


Description
Add DataKey::PaymentsByExpiry(u32) and DataKey::PaymentExpiryBuckets to index pending payments by an approximate expiry ledger bucket. (changes in fluxapay/src/lib.rs)
Implement expiry_bucket_for, index_payment_expiry, and remove_payment_from_expiry_bucket helpers and call them from create_payment and create_payments_batch to populate the index and on cancel/expire to cleanup. (changes in fluxapay/src/lib.rs)
Update batch_expire_payments to prefer processing the lowest expired bucket (up to 50 candidates) before falling back to caller-provided IDs. (changes in fluxapay/src/lib.rs)
Change account-abstraction behavior to compute and emit a SHA-256 hash of the payload via env.crypto().sha256(&payload) and store it as BytesN<32> instead of publishing the raw payload. (changes in fluxapay/src/account_abstraction.rs and fluxapay/src/events.rs)
Add a unit test asserting deterministic/distinct hashing for session payloads. (changes in fluxapay/src/account_abstraction.rs)

Testing
Ran git diff --check and staged commit; repository changes were committed successfully. (success)
Attempted cargo test -p fluxapay --lib account_abstraction --no-default-features, but the run is blocked by a pre-existing parse error in fluxapay/src/dispute_test.rs (unclosed delimiter) unrelated to these changes. (blocked)
Ran cargo check -p fluxapay --no-default-features; full check failed due to pre-existing repository compile issues (duplicate definitions / name-length and other Soroban-related errors) that predated these changes. (blocked)
cargo fmt / rustfmt could not run because of the same pre-existing parse error in fluxapay/src/dispute_test.rs. (blocked)