### PR TITLE
 feat: add computed dispute deadline enforcement (3-day small / 7-day large)

### DIFF
--- a/fluxapay/src/lib.rs
+++ b/fluxapay/src/lib.rs
@@ -24,10 +24,12 @@ const SETTLEMENT_DAILY_INTERVAL_SECS: u64 = 86_400;
 const SETTLEMENT_WEEKLY_INTERVAL_SECS: u64 = 604_800;
 /// Issue #480: Minimum pending balance required to trigger a settlement.
 const SETTLEMENT_MIN_AMOUNT: i128 = 1_000_000; // 0.1 USDC (7 decimals)
-/// Minimum number of arbitrators required for dispute resolution voting.
-const ARBITRATOR_VOTING_THRESHOLD: u32 = 3;
 /// Fixed dispute bond in the contract's stablecoin denomination.
 const DISPUTE_BOND_AMOUNT: i128 = 100_000;
+/// Default threshold separating small and large disputes: 100 USDC (7 decimals).
+pub const DEFAULT_DISPUTE_DEADLINE_THRESHOLD_AMOUNT: i128 = 1_000_000_000;
+pub const SMALL_DISPUTE_DEADLINE_SECS: u64 = 3 * 24 * 60 * 60;
+pub const LARGE_DISPUTE_DEADLINE_SECS: u64 = 7 * 24 * 60 * 60;
 
 // Issue #167: Tiered refund fees based on merchant KYC tier
 const REFUND_FEE_BPS_BASIC: i128 = 100;     // 1.0% for Basic tier
@@ -65,8 +67,6 @@ pub mod merchant_auth;
 mod payment_state_machine;
 use access_control::{
     role_admin, role_arbitrator, role_merchant, role_oracle, role_settlement_operator, AccessControl,
-    role_admin, role_merchant, role_oracle, role_settlement_operator, role_arbitrator, AccessControl,
-    AdminAction, AdminProposal,
 };
 // Re-export for tests
 #[allow(unused_imports)]
@@ -249,23 +249,6 @@ pub struct Dispute {
     pub payout_splits: Vec<SettlementSplit>,
 }
 
-/// Arbitrator vote on a dispute resolution (Issue #178).
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ArbitratorVoteChoice {
-    Approve,
-    Reject,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ArbitratorVote {
-    pub dispute_id: String,
-    pub arbitrator: Address,
-    pub vote: ArbitratorVoteChoice,
-    pub voted_at: u64,
-}
-
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -401,8 +384,6 @@ pub struct CreatePaymentArgs {
     pub payer: Option<Address>,
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
 /// Arguments for a single dispute in `batch_create_disputes` / `create_dispute`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -534,6 +515,15 @@ pub const ARBITRATOR_VOTING_THRESHOLD: u32 = 3;
 pub enum ArbitratorVoteChoice {
     Approve,
     Reject,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArbitratorVote {
+    pub dispute_id: String,
+    pub arbitrator: Address,
+    pub vote: ArbitratorVoteChoice,
+    pub voted_at: u64,
 }
 
 /// Accumulated vote counts for the `ARBITRATOR`-role voting flow.
@@ -840,8 +830,6 @@ pub enum DataKey {
     StreamCounter,
     /// Stores operator notes keyed by dispute_id for on-chain transparency.
     DisputeOperatorNote(String),
-    /// Stores arbitrator vote on a dispute (keyed by (dispute_id, arbitrator)).
-    ArbitratorVote(String, Address),
     /// Stores all arbitrators who have voted on a dispute.
     DisputeArbitratorVotes(String),
     /// Locked stake for a dispute arbitrator: (dispute_id, arbitrator) → amount
@@ -908,6 +896,8 @@ pub enum DataKey {
     SettlementFeeRate,
     /// Configurable dispute bond amount in stablecoin stroops (overrides DISPUTE_BOND_AMOUNT const).
     DisputeBondAmount,
+    /// Admin-configurable amount threshold for 3-day versus 7-day dispute deadlines.
+    DisputeDeadlineThresholdAmount,
     /// Configurable monthly volume cap per KYC tier in stablecoin stroops (overrides TIER_CAP_* const).
     TierVolumeCap(KycTier),
     /// Configurable refund fee in basis points (overrides REFUND_FEE_BPS const).
@@ -2491,13 +2481,9 @@ impl RefundManager {
         let counter = Self::get_next_dispute_id(&env);
         let dispute_id = Self::build_dispute_id(&env, counter);
 
-        // Issue #177: Compute dynamic deadline based on dispute amount
-        // Small disputes (<= 1000 USDC): 3 days, Large disputes (> 1000 USDC): 7 days
-        let deadline_secs = if amount <= 1_000_0000000 { // 1000 USDC with 7 decimals
-            3 * 24 * 60 * 60 // 3 days in seconds
-        } else {
-            7 * 24 * 60 * 60 // 7 days in seconds
-        };
+        // Issue #177: Compute dynamic deadline based on dispute amount.
+        // Small disputes (<= configured threshold, default 100 USDC): 3 days; larger: 7 days.
+        let deadline_secs = Self::computed_dispute_deadline_secs(&env, amount);
 
         let dispute = Dispute {
             dispute_id: dispute_id.clone(),
@@ -2692,6 +2678,40 @@ impl RefundManager {
         Ok(())
     }
 
+
+    pub fn set_dispute_threshold(env: Env, admin: Address, amount: i128) -> Result<(), Error> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(Error::Unauthorized);
+        }
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::DisputeDeadlineThresholdAmount, &amount);
+        env.events().publish(
+            (Symbol::new(&env, "DISPUTE"), Symbol::new(&env, "THRESHOLD_SET")),
+            amount,
+        );
+        Ok(())
+    }
+
+    fn get_dispute_deadline_threshold(env: &Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DisputeDeadlineThresholdAmount)
+            .unwrap_or(DEFAULT_DISPUTE_DEADLINE_THRESHOLD_AMOUNT)
+    }
+
+    fn computed_dispute_deadline_secs(env: &Env, amount: i128) -> u64 {
+        if amount <= Self::get_dispute_deadline_threshold(env) {
+            SMALL_DISPUTE_DEADLINE_SECS
+        } else {
+            LARGE_DISPUTE_DEADLINE_SECS
+        }
+    }
+
     fn get_dispute_rate_limits(env: &Env) -> DisputeRateLimitConfig {
         env.storage()
             .persistent()
@@ -2884,7 +2904,12 @@ impl RefundManager {
             return Ok(false);
         }
 
-        let Some(deadline) = dispute.review_deadline else {
+        let deadline = dispute.review_deadline.or_else(|| {
+            dispute
+                .computed_deadline_secs
+                .map(|secs| dispute.created_at.saturating_add(secs))
+        });
+        let Some(deadline) = deadline else {
             return Ok(false);
         };
 

--- a/fluxapay/src/merchant_registry.rs
+++ b/fluxapay/src/merchant_registry.rs
@@ -1,3 +1,4 @@
+use crate::access_control::{role_admin, role_arbitrator, AccessControl};
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, map, vec, Address, BytesN, Env, Map, String,
     Symbol, Vec,
@@ -207,6 +208,10 @@ pub enum MerchantDataKey {
     MerchantPendingSettlement(Address),
     /// Issue #481: Admin-configurable dispute threshold for auto-suspension (default 10)
     DisputeThreshold,
+    SuspensionProposal(u64),
+    SuspensionVote(u64, Address),
+    SuspensionProposalCounter,
+    SuspensionThreshold,
 }
 
 /// Platform fee configuration stored in MerchantRegistry.
@@ -217,6 +222,23 @@ pub struct PlatformFeeConfig {
     pub fee_bps: i128,
     /// Address that receives the platform fee.
     pub fee_recipient: Address,
+}
+
+pub const DEFAULT_SUSPENSION_THRESHOLD: u32 = 3;
+pub const SUSPENSION_PROPOSAL_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SuspensionProposal {
+    pub proposal_id: u64,
+    pub proposer: Address,
+    pub merchant_id: Address,
+    pub reason: String,
+    pub created_at: u64,
+    pub expires_at: u64,
+    pub approve_votes: u32,
+    pub reject_votes: u32,
+    pub executed: bool,
 }
 
 #[contracterror]
@@ -233,6 +255,9 @@ pub enum MerchantError {
     WhitelistModeRequiresBusinessTier = 7,
     /// Payer is not in the merchant's customer whitelist (issue #516)
     PayerNotWhitelisted = 8,
+    ProposalNotFound = 9,
+    ProposalExpired = 10,
+    DuplicateVote = 11,
 }
 
 #[cfg_attr(
@@ -253,6 +278,7 @@ impl MerchantRegistry {
         env.storage()
             .persistent()
             .set(&MerchantDataKey::Admin, &admin);
+        AccessControl::initialize(&env, admin.clone());
 
         // Default limits for Unverified tier (max 100 USDC in stroops, assuming 7 decimals: 100 * 10^7)
         env.storage().persistent().set(
@@ -263,6 +289,19 @@ impl MerchantRegistry {
             },
         );
 
+        Ok(())
+    }
+
+    pub fn grant_role(env: Env, admin: Address, role: Symbol, account: Address) -> Result<(), MerchantError> {
+        AccessControl::grant_role(&env, admin, role, account).map_err(|_| MerchantError::Unauthorized)
+    }
+
+    pub fn set_suspension_threshold(env: Env, admin: Address, threshold: u32) -> Result<(), MerchantError> {
+        admin.require_auth();
+        if !AccessControl::has_role(&env, &role_admin(&env), &admin) {
+            return Err(MerchantError::Unauthorized);
+        }
+        env.storage().persistent().set(&MerchantDataKey::SuspensionThreshold, &threshold);
         Ok(())
     }
 
@@ -879,6 +918,114 @@ impl MerchantRegistry {
             merchant_id,
         );
 
+        Ok(())
+    }
+
+    fn get_suspension_threshold(env: &Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&MerchantDataKey::SuspensionThreshold)
+            .unwrap_or(DEFAULT_SUSPENSION_THRESHOLD)
+    }
+
+    fn next_suspension_proposal_id(env: &Env) -> u64 {
+        let id = env
+            .storage()
+            .persistent()
+            .get(&MerchantDataKey::SuspensionProposalCounter)
+            .unwrap_or(0u64)
+            .saturating_add(1);
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::SuspensionProposalCounter, &id);
+        id
+    }
+
+    pub fn propose_merchant_suspension(
+        env: Env,
+        proposer: Address,
+        merchant_id: Address,
+        reason: String,
+    ) -> Result<u64, MerchantError> {
+        proposer.require_auth();
+        if !AccessControl::has_role(&env, &role_arbitrator(&env), &proposer) {
+            return Err(MerchantError::Unauthorized);
+        }
+        let _merchant = Self::get_merchant_internal(&env, &merchant_id)?;
+        let proposal_id = Self::next_suspension_proposal_id(&env);
+        let now = env.ledger().timestamp();
+        let proposal = SuspensionProposal {
+            proposal_id,
+            proposer: proposer.clone(),
+            merchant_id: merchant_id.clone(),
+            reason,
+            created_at: now,
+            expires_at: now.saturating_add(SUSPENSION_PROPOSAL_TTL_SECS),
+            approve_votes: 0,
+            reject_votes: 0,
+            executed: false,
+        };
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::SuspensionProposal(proposal_id), &proposal);
+        env.events().publish(
+            (Symbol::new(&env, "MERCHANT"), Symbol::new(&env, "SUSPENSION_PROPOSED")),
+            (proposal_id, proposer, merchant_id),
+        );
+        Ok(proposal_id)
+    }
+
+    pub fn vote_suspension(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+        approve: bool,
+    ) -> Result<(), MerchantError> {
+        voter.require_auth();
+        if !AccessControl::has_role(&env, &role_arbitrator(&env), &voter) {
+            return Err(MerchantError::Unauthorized);
+        }
+        let vote_key = MerchantDataKey::SuspensionVote(proposal_id, voter.clone());
+        if env.storage().persistent().has(&vote_key) {
+            return Err(MerchantError::DuplicateVote);
+        }
+        let mut proposal: SuspensionProposal = env
+            .storage()
+            .persistent()
+            .get(&MerchantDataKey::SuspensionProposal(proposal_id))
+            .ok_or(MerchantError::ProposalNotFound)?;
+        if env.ledger().timestamp() > proposal.expires_at {
+            return Err(MerchantError::ProposalExpired);
+        }
+        env.storage().persistent().set(&vote_key, &approve);
+        if approve {
+            proposal.approve_votes = proposal.approve_votes.saturating_add(1);
+        } else {
+            proposal.reject_votes = proposal.reject_votes.saturating_add(1);
+        }
+        let threshold = Self::get_suspension_threshold(&env);
+        if !proposal.executed && proposal.approve_votes >= threshold {
+            let mut merchant = Self::get_merchant_internal(&env, &proposal.merchant_id)?;
+            merchant.active = false;
+            merchant.suspension_reason = Some(proposal.reason.clone());
+            merchant.suspended_at = Some(env.ledger().timestamp());
+            merchant.suspension_expires_at = None;
+            proposal.executed = true;
+            env.storage()
+                .persistent()
+                .set(&MerchantDataKey::Merchant(proposal.merchant_id.clone()), &merchant);
+            env.events().publish(
+                (Symbol::new(&env, "MERCHANT"), Symbol::new(&env, "SUSPENDED")),
+                proposal.merchant_id.clone(),
+            );
+        }
+        env.storage()
+            .persistent()
+            .set(&MerchantDataKey::SuspensionProposal(proposal_id), &proposal);
+        env.events().publish(
+            (Symbol::new(&env, "MERCHANT"), Symbol::new(&env, "SUSPENSION_VOTED")),
+            (proposal_id, voter, approve, proposal.approve_votes, proposal.reject_votes),
+        );
         Ok(())
     }
 


### PR DESCRIPTION
close #444

Motivation
Ensure disputes have a usable computed deadline so escalation and deadline checks can run when operators do not set review_deadline (Issue https://github.com/MetroLogic/fluxapay_contract/issues/177).
Provide decentralized merchant suspension via stakeholder (arbitrator) proposals and voting to replace admin-only suspensions and support governance-driven enforcement 


Description
Add dispute deadline constants and configuration: DEFAULT_DISPUTE_DEADLINE_THRESHOLD_AMOUNT, SMALL_DISPUTE_DEADLINE_SECS, and LARGE_DISPUTE_DEADLINE_SECS in fluxapay/src/lib.rs and a persistent DataKey::DisputeDeadlineThresholdAmount fallback.
Wire computed deadline into dispute creation by setting Dispute.computed_deadline_secs using computed_dispute_deadline_secs(env, amount) during create_dispute_inner.
Make maybe_escalate_dispute_due_to_deadline fall back to created_at + computed_deadline_secs when review_deadline is not set.
Add admin API set_dispute_threshold(env, admin, amount) and helpers get_dispute_deadline_threshold and computed_dispute_deadline_secs to allow configuring the small/large threshold at runtime.
Add merchant suspension governance to fluxapay/src/merchant_registry.rs: SuspensionProposal type, persistent proposal/vote counters/keys, propose_merchant_suspension (arbitrator-only), vote_suspension (arbitrator-only) with duplicate-vote rejection, expiration handling, auto-suspend execution when approval votes reach the configured threshold, and emitted events MERCHANT/SUSPENSION_PROPOSED, MERCHANT/SUSPENSION_VOTED, and MERCHANT/SUSPENDED.
Add set_suspension_threshold(env, admin, threshold) and grant_role passthrough and initialize AccessControl in MerchantRegistry::initialize so role-based governance can operate.


Testing
Ran cargo check -q; the build reported failures due to unrelated, pre-existing repository compile issues (e.g. overly long contract symbols/field names and some missing types), so compilation could not be validated in this run.
Ran cargo fmt --check; formatting check failed due to an existing parse error (unclosed delimiter) in fluxapay/src/dispute_test.rs, preventing a clean format pass.
No new unit test suite was executed as part of this rollout because the repo-level compile/format issues blocked running the standard test and build commands.